### PR TITLE
feat#23/유저 회원가입 로직 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.6'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'jacoco'
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.wootecam'
@@ -137,16 +136,14 @@ jacocoTestReport {
 // queryDSL 추가 : QueryDSL 빌드 옵션
 def querydslDir = "$buildDir/generated/querydsl"
 
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
 sourceSets {
-    main.java.srcDir querydslDir
+    main.java.srcDirs += [querydslDir]
 }
-configurations {
-    querydsl.extendsFrom compileClasspath
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
 }
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/wootecam/festivals/domain/member/controller/MemberController.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.wootecam.festivals.domain.member.controller;
+
+import com.wootecam.festivals.domain.member.dto.MemberCreateDto;
+import com.wootecam.festivals.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 유저 회원가입
+    @PostMapping
+    public ResponseEntity<?> signUpMember(@RequestBody MemberCreateDto memberCreateDto) {
+        //TODO 공통 응답 클래스 필요ㅌ
+        return new ResponseEntity<>(memberService.createMember(memberCreateDto), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/member/dto/MemberCreateDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/dto/MemberCreateDto.java
@@ -1,0 +1,4 @@
+package com.wootecam.festivals.domain.member.dto;
+
+public record MemberCreateDto(String memberName, String email, String profileImg) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/member/dto/MemberCreateDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/dto/MemberCreateDto.java
@@ -1,4 +1,13 @@
 package com.wootecam.festivals.domain.member.dto;
 
+import com.wootecam.festivals.domain.member.entity.Member;
+
 public record MemberCreateDto(String memberName, String email, String profileImg) {
+    public Member toEntity() {
+        return Member.builder()
+                .memberName(this.memberName)
+                .email(this.email)
+                .profileImg(this.profileImg)
+                .build();
+    }
 }

--- a/src/main/java/com/wootecam/festivals/domain/member/entity/Member.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/entity/Member.java
@@ -1,0 +1,36 @@
+package com.wootecam.festivals.domain.member.entity;
+
+import com.wootecam.festivals.global.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+    private String memberName;
+    private String email;
+    private String profileImg;
+    private boolean isDeleted;
+
+    @Builder
+    private Member(String memberName, String email, String profileImg) {
+        this.memberName = Objects.requireNonNull(memberName, "memberName must be provided.");
+        this.email = Objects.requireNonNull(email, "email must be provided.");
+        this.profileImg = profileImg;
+        this.isDeleted = false;
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.wootecam.festivals.domain.member.repository;
+
+import com.wootecam.festivals.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/wootecam/festivals/domain/member/service/MemberService.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/service/MemberService.java
@@ -1,0 +1,12 @@
+package com.wootecam.festivals.domain.member.service;
+
+import com.wootecam.festivals.domain.member.entity.Member;
+
+public interface MemberService {
+
+    Member createMember(MemberCreateDto dto);
+
+    Member getMember(Long id);
+
+    void deleteMember(Long id);
+}

--- a/src/main/java/com/wootecam/festivals/domain/member/service/MemberService.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/service/MemberService.java
@@ -2,12 +2,24 @@ package com.wootecam.festivals.domain.member.service;
 
 import com.wootecam.festivals.domain.member.dto.MemberCreateDto;
 import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
-public interface MemberService {
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
 
-    Member createMember(MemberCreateDto dto);
+    public Member createMember(MemberCreateDto memberCreateDto) {
+        return memberRepository.save(memberCreateDto.toEntity());
+    }
 
-    Member getMember(Long id);
+    public Member getMember(Long id) {
+        return null;
+    }
 
-    void deleteMember(Long id);
+    public void deleteMember(Long id) {
+
+    }
 }

--- a/src/main/java/com/wootecam/festivals/domain/member/service/MemberService.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.wootecam.festivals.domain.member.service;
 
+import com.wootecam.festivals.domain.member.dto.MemberCreateDto;
 import com.wootecam.festivals.domain.member.entity.Member;
 
 public interface MemberService {

--- a/src/main/java/com/wootecam/festivals/global/BaseEntity.java
+++ b/src/main/java/com/wootecam/festivals/global/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.wootecam.festivals.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/wootecam/festivals/global/JpaConfig.java
+++ b/src/main/java/com/wootecam/festivals/global/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.wootecam.festivals.global;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
## ✅ PR 체크
- [x] 하나의 PR 에는 100줄 정도의 커밋을 한다는 규칙을 지키고 있나요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [x] 팀원 한 명을 Assign 했나요?
- [x] 작업 범위에 대해서 테스트를 작성하셨나요?

## 🚨 관련 이슈
#23 (아직 테스트 코드가 없어 클로즈하지 않음)

## 🌈 작업 상황
- 아직 테스트 코드가 없어 빌드가 되지 않습니다. (jacoco 이슈)
- 해당 PR 은 팀 코드 스타일과 구조를 맞추기 위함이기 때문에 해당 사항을 위주로 리뷰해주시면 좋을거 같습니다.
- 고려사항 1. 서비스단 인터페이스 도입 여부
인터페이스 도입의 주요 이점으로는 다형성을 활용한 구체 코드 변경의 용이성과 테스트 코드에서의 모킹 간소화가 있습니다. 이는 코드의 유연성과 테스트 효율성을 높이는 데 도움이 됩니다.

그러나 서비스 계층은 비즈니스 로직을 담당하며, 상대적으로 변경 빈도가 낮은 편입니다. 이로 인해 인터페이스 도입의 실질적 필요성에 대한 의문이 제기되었습니다.

협업 측면에서 살펴보면, 팀원들의 코드가 아직 병합되지 않은 상황에서도 인터페이스를 기반으로 작업할 수 있어 개발 진행이 수월해질 수 있습니다. 이는 특히 대규모 프로젝트나 마이크로서비스 아키텍처에서 유용할 수 있습니다.

이러한 장단점을 고려한 결과, 서비스 계층에 인터페이스를 도입하기로 결정했습니다. 초기에는 추가 작업이 필요하지만, 장기적으로 코드의 확장성과 유지보수성, 그리고 팀 협업에 긍정적인 영향을 미칠 것으로 예상됩니다.

- 고려사항 2. DTO와 Entity 둘 다 검증 할 것인가?

https://stackoverflow.com/questions/19100317/spring-dto-validation-in-service-or-controller
https://softwareengineering.stackexchange.com/questions/387763/should-i-validate-dtos-or-entities
https://stackoverflow.com/questions/42280355/spring-rest-api-validation-should-be-in-dto-or-in-entity

둘 다 하는게 맞다. 당연히 프론트단에서 전달되는 자료의 검증과 db에 들어가는 데이터의 검증이 별도로 동작해야한다.