### PR TITLE
feat#17/create festival

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-core'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // Jackson의 Java 8 날짜/시간 모듈
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-core'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
@@ -1,0 +1,25 @@
+package com.wootecam.festivals.domain.festival.controller;
+
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.service.FestivalService;
+import com.wootecam.festivals.global.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/festivals")
+@RequiredArgsConstructor
+public class FestivalController {
+
+    private final FestivalService festivalService;
+
+    @PostMapping
+    public ApiResponse<Long> createFestival(@Valid @RequestBody FestivalCreateRequestDto requestDto) {
+        Long festivalId = festivalService.createFestival(requestDto);
+        return ApiResponse.of(festivalId);
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.domain.festival.controller;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponseDto;
 import com.wootecam.festivals.domain.festival.service.FestivalService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import jakarta.validation.Valid;
@@ -18,8 +19,9 @@ public class FestivalController {
     private final FestivalService festivalService;
 
     @PostMapping
-    public ApiResponse<Long> createFestival(@Valid @RequestBody FestivalCreateRequestDto requestDto) {
-        Long festivalId = festivalService.createFestival(requestDto);
-        return ApiResponse.of(festivalId);
+    public ApiResponse<FestivalCreateResponseDto> createFestival(
+            @Valid @RequestBody FestivalCreateRequestDto requestDto) {
+        FestivalCreateResponseDto responseDto = festivalService.createFestival(requestDto);
+        return ApiResponse.of(responseDto);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestDto.java
@@ -1,13 +1,31 @@
 package com.wootecam.festivals.domain.festival.dto;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record FestivalCreateRequestDto(
+        @NotNull(message = "주최 단체 정보는 필수입니다.")
         Long organizationId,
+
+        @NotBlank(message = "축제 제목은 필수입니다.")
+        @Size(min = 1, max = 100, message = "축제 제목은 1자 이상 100자 이하여야 합니다.")
         String title,
+
+        @NotBlank(message = "축제 설명은 필수입니다.")
+        @Size(max = 1000, message = "축제 설명은 1000자 이하여야 합니다.")
         String description,
+
+        @NotNull(message = "시작 시간은 필수입니다.")
+        @Future(message = "시작 시간은 현재보다 미래여야 합니다.")
         LocalDateTime startTime,
+
+        @NotNull(message = "종료 시간은 필수입니다.")
+        @Future(message = "종료 시간은 현재보다 미래여야 합니다.")
         LocalDateTime endTime
 ) {
     public Festival toEntity() {
@@ -18,5 +36,10 @@ public record FestivalCreateRequestDto(
                 .startTime(startTime)
                 .endTime(endTime)
                 .build();
+    }
+
+    @AssertTrue(message = "종료 시간은 시작 시간보다 늦어야 합니다.")
+    private boolean isEndTimeAfterStartTime() {
+        return endTime != null && startTime != null && endTime.isAfter(startTime);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestDto.java
@@ -1,0 +1,22 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import java.time.LocalDateTime;
+
+public record FestivalCreateRequestDto(
+        Long organizationId,
+        String title,
+        String description,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {
+    public Festival toEntity() {
+        return Festival.builder()
+                .organizationId(organizationId)
+                .title(title)
+                .description(description)
+                .startTime(startTime)
+                .endTime(endTime)
+                .build();
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateResponseDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateResponseDto.java
@@ -1,0 +1,11 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+
+public record FestivalCreateResponseDto(
+        Long festivalId
+) {
+    public static FestivalCreateResponseDto toResponse(Festival festival) {
+        return new FestivalCreateResponseDto(festival.getId());
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateResponseDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateResponseDto.java
@@ -1,11 +1,23 @@
 package com.wootecam.festivals.domain.festival.dto;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
+import com.wootecam.festivals.global.exception.type.ApiException;
 
 public record FestivalCreateResponseDto(
         Long festivalId
 ) {
-    public static FestivalCreateResponseDto toResponse(Festival festival) {
+    public static FestivalCreateResponseDto from(Festival festival) {
+        validateFestival(festival);
         return new FestivalCreateResponseDto(festival.getId());
+    }
+
+    private static void validateFestival(Festival festival) {
+        if (festival == null) {
+            throw new ApiException(FestivalErrorCode.InvalidFestivalDataException, "Festival 객체가 null입니다.");
+        }
+        if (festival.getId() == null) {
+            throw new ApiException(FestivalErrorCode.InvalidFestivalDataException, "Festival Id가 null입니다.");
+        }
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -22,15 +23,30 @@ public class Festival extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "festival_id")
     private Long id;
+
+    @NotNull
+    @Column(name = "organization_id", nullable = false)
     private Long organizationId; //TODO: Organization으로 ManyToOne 변경 예정
+
+    @NotNull
+    @Column(nullable = false, length = 100)
     private String title;
+
+    @NotNull
+    @Column(nullable = false, length = 2000)
     private String description;
+
+    @NotNull
+    @Column(name = "start_time", nullable = false)
     private LocalDateTime startTime;
+
+    @NotNull
+    @Column(name = "end_time", nullable = false)
     private LocalDateTime endTime;
 
     @Builder
     private Festival(Long organizationId, String title, String description, LocalDateTime startTime,
-                    LocalDateTime endTime) {
+                     LocalDateTime endTime) {
         this.organizationId = Objects.requireNonNull(organizationId);
         this.title = Objects.requireNonNull(title);
         this.description = Objects.requireNonNull(description);

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -29,7 +29,7 @@ public class Festival extends BaseEntity {
     private LocalDateTime endTime;
 
     @Builder
-    public Festival(Long organizationId, String title, String description, LocalDateTime startTime,
+    private Festival(Long organizationId, String title, String description, LocalDateTime startTime,
                     LocalDateTime endTime) {
         this.organizationId = Objects.requireNonNull(organizationId);
         this.title = Objects.requireNonNull(title);

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -1,0 +1,40 @@
+package com.wootecam.festivals.domain.festival.entity;
+
+import com.wootecam.festivals.global.audit.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Festival extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "festival_id")
+    private Long id;
+    private Long organizationId; //TODO: Organization으로 ManyToOne 변경 예정
+    private String title;
+    private String description;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    @Builder
+    public Festival(Long organizationId, String title, String description, LocalDateTime startTime,
+                    LocalDateTime endTime) {
+        this.organizationId = Objects.requireNonNull(organizationId);
+        this.title = Objects.requireNonNull(title);
+        this.description = Objects.requireNonNull(description);
+        this.startTime = Objects.requireNonNull(startTime);
+        this.endTime = Objects.requireNonNull(endTime);
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/exception/FestivalErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/exception/FestivalErrorCode.java
@@ -1,0 +1,33 @@
+package com.wootecam.festivals.domain.festival.exception;
+
+import com.wootecam.festivals.global.docs.EnumType;
+import com.wootecam.festivals.global.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum FestivalErrorCode implements ErrorCode, EnumType {
+
+    // 클라이언트 오류
+    InvalidFestivalDataException(HttpStatus.BAD_REQUEST, "FS-C-0001", "Festival 데이터에 문제가 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    FestivalErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public String getDescription() {
+        return httpStatus + ": " + code + " - " + message;
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -1,0 +1,7 @@
+package com.wootecam.festivals.domain.festival.repository;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FestivalRepository extends JpaRepository<Festival, Long> {
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
@@ -1,0 +1,21 @@
+package com.wootecam.festivals.domain.festival.service;
+
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FestivalService {
+
+    private final FestivalRepository festivalRepository;
+
+    public Long createFestival(FestivalCreateRequestDto requestDto) {
+        Festival festival = requestDto.toEntity();
+        // TODO: festival 유효성 검사 필요
+        Festival savedFestival = festivalRepository.save(festival);
+        return savedFestival.getId();
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.domain.festival.service;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponseDto;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,10 +13,10 @@ public class FestivalService {
 
     private final FestivalRepository festivalRepository;
 
-    public Long createFestival(FestivalCreateRequestDto requestDto) {
+    public FestivalCreateResponseDto createFestival(FestivalCreateRequestDto requestDto) {
         Festival festival = requestDto.toEntity();
-        // TODO: festival 유효성 검사 필요
+        // TODO: festival 유효성 검사 필요 ex) organization의 유효성 여부 등
         Festival savedFestival = festivalRepository.save(festival);
-        return savedFestival.getId();
+        return FestivalCreateResponseDto.toResponse(savedFestival);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
@@ -17,6 +17,6 @@ public class FestivalService {
         Festival festival = requestDto.toEntity();
         // TODO: festival 유효성 검사 필요 ex) organization의 유효성 여부 등
         Festival savedFestival = festivalRepository.save(festival);
-        return FestivalCreateResponseDto.toResponse(savedFestival);
+        return FestivalCreateResponseDto.from(savedFestival);
     }
 }

--- a/src/main/java/com/wootecam/festivals/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/wootecam/festivals/global/exception/ApiExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(basePackages = "com.wootecam.festivals.domain")
 @Slf4j
-@Order(Ordered.LOWEST_PRECEDENCE)
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class ApiExceptionHandler {
 
     @ExceptionHandler(ApiException.class)

--- a/src/main/java/com/wootecam/festivals/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wootecam/festivals/global/exception/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -31,20 +30,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BindException.class)
     public ResponseEntity<ApiErrorResponse> handleBindException(BindException exception) {
         String errorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-
-        ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
-                errorMessage);
-
-        log.error("{}", errorResponse);
-
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse);
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        String errorMessage = ex.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
 
         ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
                 errorMessage);

--- a/src/main/java/com/wootecam/festivals/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wootecam/festivals/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,6 +31,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BindException.class)
     public ResponseEntity<ApiErrorResponse> handleBindException(BindException exception) {
         String errorMessage = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
+                errorMessage);
+
+        log.error("{}", errorResponse);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
 
         ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
                 errorMessage);

--- a/src/test/java/com/wootecam/festivals/docs/utils/RestDocsSupport.java
+++ b/src/test/java/com/wootecam/festivals/docs/utils/RestDocsSupport.java
@@ -3,6 +3,10 @@ package com.wootecam.festivals.docs.utils;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wootecam.festivals.global.exception.ApiExceptionHandler;
+import com.wootecam.festivals.global.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Import;
@@ -41,11 +45,15 @@ public abstract class RestDocsSupport {
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+                .setControllerAdvice(new ApiExceptionHandler(), new GlobalExceptionHandler())
                 .apply(documentationConfiguration(provider))
                 .alwaysDo(MockMvcResultHandlers.print())
                 .alwaysDo(restDocs)
                 .addFilter(new CharacterEncodingFilter("UTF-8", true))
                 .build();
+
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     protected abstract Object initController();

--- a/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
@@ -1,0 +1,125 @@
+package com.wootecam.festivals.domain.festival.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wootecam.festivals.docs.utils.RestDocsSupport;
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.service.FestivalService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(FestivalController.class)
+@ActiveProfiles("test")
+class FestivalControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private FestivalService festivalService;
+
+    private FestivalController festivalController;
+
+    private FestivalCreateRequestDto validRequestDto;
+
+    @Override
+    protected Object initController() {
+        festivalController = new FestivalController(festivalService);
+        return festivalController;
+    }
+
+    @BeforeEach
+    void setUp() {
+        validRequestDto = new FestivalCreateRequestDto(
+                1L,
+                "Summer Music Festival",
+                "A vibrant music festival featuring various artists",
+                LocalDateTime.now().plusDays(30),
+                LocalDateTime.now().plusDays(32)
+        );
+    }
+
+    @Test
+    @DisplayName("축제 생성 API")
+    void createFestival() throws Exception {
+        // Given
+        Long expectedFestivalId = 1L;
+        given(festivalService.createFestival(any(FestivalCreateRequestDto.class)))
+                .willReturn(expectedFestivalId);
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/festivals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(expectedFestivalId))
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("organizationId").type(JsonFieldType.NUMBER)
+                                        .description("주최 단체 ID"),
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("축제 제목"),
+                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                        .description("축제 설명"),
+                                fieldWithPath("startTime").type(JsonFieldType.STRING)
+                                        .description("축제 시작 시간 (ISO-8601 형식)"),
+                                fieldWithPath("endTime").type(JsonFieldType.STRING)
+                                        .description("축제 종료 시간 (ISO-8601 형식)")
+                        ),
+                        responseFields(
+                                fieldWithPath("data").type(JsonFieldType.NUMBER)
+                                        .description("생성된 축제 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("축제 생성 API - 잘못된 입력")
+    void createFestival_InvalidInput() throws Exception {
+        // Given
+        FestivalCreateRequestDto invalidRequestDto = new FestivalCreateRequestDto(
+                null,
+                "",
+                "Description",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1)
+        );
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/festivals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequestDto)))
+                .andExpect(status().isBadRequest())
+                .andDo(restDocs.document(
+                        requestFields(
+                                fieldWithPath("organizationId").type(JsonFieldType.NULL)
+                                        .description("주최 단체 ID (필수)"),
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("축제 제목 (필수, 공백 불가)"),
+                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                        .description("축제 설명"),
+                                fieldWithPath("startTime").type(JsonFieldType.STRING)
+                                        .description("축제 시작 시간 (현재 시간 이후여야 함)"),
+                                fieldWithPath("endTime").type(JsonFieldType.STRING)
+                                        .description("축제 종료 시간 (시작 시간 이후여야 함)")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").type(JsonFieldType.STRING)
+                                        .description("에러 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("에러 메시지")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wootecam.festivals.docs.utils.RestDocsSupport;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponseDto;
 import com.wootecam.festivals.domain.festival.service.FestivalService;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,15 +56,16 @@ class FestivalControllerTest extends RestDocsSupport {
     void createFestival() throws Exception {
         // Given
         Long expectedFestivalId = 1L;
+        FestivalCreateResponseDto responseDto = new FestivalCreateResponseDto(expectedFestivalId);
         given(festivalService.createFestival(any(FestivalCreateRequestDto.class)))
-                .willReturn(expectedFestivalId);
+                .willReturn(responseDto);
 
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/festivals")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validRequestDto)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value(expectedFestivalId))
+                .andExpect(jsonPath("$.data.festivalId").value(expectedFestivalId))
                 .andDo(restDocs.document(
                         requestFields(
                                 fieldWithPath("organizationId").type(JsonFieldType.NUMBER)
@@ -78,7 +80,7 @@ class FestivalControllerTest extends RestDocsSupport {
                                         .description("축제 종료 시간 (ISO-8601 형식)")
                         ),
                         responseFields(
-                                fieldWithPath("data").type(JsonFieldType.NUMBER)
+                                fieldWithPath("data.festivalId").type(JsonFieldType.NUMBER)
                                         .description("생성된 축제 ID")
                         )
                 ));

--- a/src/test/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestDtoTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestDtoTest.java
@@ -1,0 +1,58 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FestivalCreateRequestDtoTest {
+
+    private final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    private final Validator validator = factory.getValidator();
+
+    private static Stream<Arguments> invalidDtoProvider() {
+        LocalDateTime now = LocalDateTime.now();
+        return Stream.of(
+                Arguments.of(null, "Title", "Description", now.plusDays(1), now.plusDays(2), "주최 단체 정보는 필수입니다."),
+                Arguments.of(1L, "", "Description", now.plusDays(1), now.plusDays(2), "축제 제목은 필수입니다."),
+                Arguments.of(1L, "Title", "", now.plusDays(1), now.plusDays(2), "축제 설명은 필수입니다."),
+                Arguments.of(1L, "Title", "Description", now.minusDays(1), now.plusDays(2), "시작 시간은 현재보다 미래여야 합니다."),
+                Arguments.of(1L, "Title", "Description", now.plusDays(2), now.plusDays(1), "종료 시간은 시작 시간보다 늦어야 합니다.")
+        );
+    }
+
+    @Test
+    @DisplayName("유효한 데이터로 DTO 생성 시 검증 통과")
+    void validDtoShouldPass() {
+        LocalDateTime now = LocalDateTime.now();
+        FestivalCreateRequestDto dto = new FestivalCreateRequestDto(
+                1L, "Summer Festival", "A great summer festival",
+                now.plusDays(1), now.plusDays(2)
+        );
+
+        var violations = validator.validate(dto);
+        assertThat(violations).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidDtoProvider")
+    @DisplayName("잘못된 데이터로 DTO 생성 시 검증 실패")
+    void invalidDtoShouldFail(Long organizationId, String title, String description,
+                              LocalDateTime startTime, LocalDateTime endTime, String expectedViolation) {
+        FestivalCreateRequestDto dto = new FestivalCreateRequestDto(
+                organizationId, title, description, startTime, endTime
+        );
+
+        var violations = validator.validate(dto);
+        assertThat(violations).isNotEmpty();
+        assertThat(violations.stream().map(v -> v.getMessage()).toList()).contains(expectedViolation);
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateResponseDtoTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateResponseDtoTest.java
@@ -1,0 +1,58 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
+import com.wootecam.festivals.domain.festival.stub.FestivalStub;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("FestivalCreateResponseDto 테스트")
+class FestivalCreateResponseDtoTest {
+
+    @Nested
+    @DisplayName("from 메서드는")
+    class Describe_from {
+
+        @Test
+        @DisplayName("유효한 Festival 객체가 주어지면 FestivalCreateResponseDto를 반환한다")
+        void it_returns_festivalCreateResponseDto_when_given_valid_festival() {
+            // Given
+            Long expectedId = 1L;
+            Festival festival = FestivalStub.createValidFestival(expectedId);
+
+            // When
+            FestivalCreateResponseDto responseDto = FestivalCreateResponseDto.from(festival);
+
+            // Then
+            assertThat(responseDto.festivalId()).isEqualTo(expectedId);
+        }
+
+        @Test
+        @DisplayName("null Festival 객체가 주어지면 ApiException을 던진다")
+        void it_throws_apiException_when_given_null_festival() {
+            // When & Then
+            assertThatThrownBy(() -> FestivalCreateResponseDto.from(null))
+                    .isInstanceOf(ApiException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", FestivalErrorCode.InvalidFestivalDataException)
+                    .hasMessage("Festival 객체가 null입니다.");
+        }
+
+        @Test
+        @DisplayName("ID가 null인 Festival 객체가 주어지면 ApiException을 던진다")
+        void it_throws_apiException_when_given_festival_with_null_id() {
+            // Given
+            Festival festivalWithNullId = FestivalStub.createFestivalWithNullId();
+
+            // When & Then
+            assertThatThrownBy(() -> FestivalCreateResponseDto.from(festivalWithNullId))
+                    .isInstanceOf(ApiException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", FestivalErrorCode.InvalidFestivalDataException)
+                    .hasMessage("Festival Id가 null입니다.");
+        }
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponseDto;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.utils.TestDBCleaner;
@@ -51,12 +52,12 @@ class FestivalServiceTest {
             );
 
             // When
-            Long festivalId = festivalService.createFestival(requestDto);
+            FestivalCreateResponseDto responseDto = festivalService.createFestival(requestDto);
 
             // Then
-            assertThat(festivalId).isNotNull();
+            assertThat(responseDto).isNotNull();
 
-            Festival savedFestival = festivalRepository.findById(festivalId)
+            Festival savedFestival = festivalRepository.findById(responseDto.festivalId())
                     .orElseThrow(() -> new AssertionError("저장된 축제를 찾을 수 없습니다."));
 
             assertThat(savedFestival)

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
@@ -1,0 +1,72 @@
+package com.wootecam.festivals.domain.festival.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequestDto;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.utils.TestDBCleaner;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("FestivalService의 ")
+class FestivalServiceTest {
+
+    @Autowired
+    FestivalService festivalService;
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @BeforeEach
+    void setUp() {
+        TestDBCleaner.clear(festivalRepository);
+    }
+
+    @Nested
+    @DisplayName("축제 생성 메서드는 ")
+    class CreateFestival {
+
+        @Test
+        @DisplayName("유효한 정보로 축제를 생성할 수 있다")
+        void createValidFestival() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            FestivalCreateRequestDto requestDto = new FestivalCreateRequestDto(
+                    1L, // organizationId
+                    "테스트 축제",
+                    "축제 설명",
+                    now,
+                    now.plusDays(7)
+            );
+
+            // When
+            Long festivalId = festivalService.createFestival(requestDto);
+
+            // Then
+            assertThat(festivalId).isNotNull();
+
+            Festival savedFestival = festivalRepository.findById(festivalId)
+                    .orElseThrow(() -> new AssertionError("저장된 축제를 찾을 수 없습니다."));
+
+            assertThat(savedFestival)
+                    .satisfies(festival -> {
+                        assertThat(festival.getOrganizationId()).isEqualTo(1L);
+                        assertThat(festival.getTitle()).isEqualTo("테스트 축제");
+                        assertThat(festival.getDescription()).isEqualTo("축제 설명");
+                        assertThat(festival.getStartTime()).isCloseTo(now, within(1, ChronoUnit.SECONDS));
+                        assertThat(festival.getEndTime()).isCloseTo(now.plusDays(7), within(1, ChronoUnit.SECONDS));
+                    });
+        }
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/festival/stub/FestivalStub.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/stub/FestivalStub.java
@@ -1,0 +1,65 @@
+package com.wootecam.festivals.domain.festival.stub;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import java.time.LocalDateTime;
+
+public class FestivalStub extends Festival {
+
+    private final Long id;
+    private final Long organizationId;
+    private final String title;
+    private final String description;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+
+    private FestivalStub(Long id, Long organizationId, String title, String description,
+                         LocalDateTime startTime, LocalDateTime endTime) {
+        super();
+        this.id = id;
+        this.organizationId = organizationId;
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static FestivalStub createValidFestival(Long id) {
+        return new FestivalStub(id, 1L, "Test Festival", "Test Description",
+                LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+    }
+
+    public static FestivalStub createFestivalWithNullId() {
+        return new FestivalStub(null, 1L, "Test Festival", "Test Description",
+                LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+    }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    @Override
+    public Long getOrganizationId() {
+        return organizationId;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+}


### PR DESCRIPTION
## ✅ PR 체크
- [ ] 하나의 PR 에는 100줄 정도의 커밋을 한다는 규칙을 지키고 있나요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [x] 팀원 한 명을 Assign 했나요?
- [x] 작업 범위에 대해서 테스트를 작성하셨나요?

## 🚨 관련 이슈
closes #17 

## 🌈 작업 상황
- DB의 Festival 테이블와 연결되는 Festival 엔티티를 생성했습니다.
- Festival 생성을 위한 DTO를 생성했습니다.
- DTO에 Spring Validation을 통해 Validate를 진행하고 있습니다.
- 축제 시작 시간이 종료 시간보다 늦은 경우 예외를 발생시킵니다.
- RestDocsSupport에 Jackson 라이브러리의 LocalDateTime 파싱을 추가했습니다.
- 테스트시에 ExceptionHandler를 편하게 사용하기 위해 RestDocsSupport에 ExceptionHandler를 추가했습니다.
- ExceptionHandler의 우선순위를 조정했습니다.
- GlobalExceptionHandler에 MethodArgumentNotValidException를 처리하는 메서드를 추가했습니다.

## 📌 기타
