### PR TITLE
feat#45/Festival 리스트 페이지네이션 구현

### DIFF
--- a/src/docs/asciidoc/api/domain/festival/Festival.adoc
+++ b/src/docs/asciidoc/api/domain/festival/Festival.adoc
@@ -36,3 +36,40 @@ include::{snippets}/festival-controller-test/get-festival-detail_-not-found/path
 
 include::{snippets}/festival-controller-test/get-festival-detail_-not-found/http-response.adoc[]
 include::{snippets}/festival-controller-test/get-festival-detail_-not-found/response-fields.adoc[]
+
+=== 축제 목록 조회 API (페이지네이션)
+
+==== HTTP Request
+
+include::{snippets}/festival-controller-test/get-festivals/http-request.adoc[]
+include::{snippets}/festival-controller-test/get-festivals/query-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/festival-controller-test/get-festivals/http-response.adoc[]
+include::{snippets}/festival-controller-test/get-festivals/response-fields.adoc[]
+
+==== 사용 예시
+
+===== 첫 페이지 요청
+
+----
+GET /api/v1/festivals?pageSize=10
+----
+
+===== 다음 페이지 요청
+
+----
+GET /api/v1/festivals?cursorDate=2024-08-17&cursorId=2&pageSize=10
+----
+
+==== 설명
+
+- `cursorDate`: 이전 페이지의 마지막 축제 시작일.
+첫 페이지 요청 시 생략 가능.
+- `cursorId`: 이전 페이지의 마지막 축제 ID.
+첫 페이지 요청 시 생략 가능.
+- `pageSize`: 한 페이지에 표시할 축제 수. 기본값은 10.
+
+응답의 `cursor` 필드에는 다음 페이지 요청 시 사용할 `date`와 `id` 값이 포함됩니다.
+`hasNext` 필드가 `false`이면 더 이상 조회할 페이지가 없음을 의미합니다.

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
@@ -8,7 +8,9 @@ import com.wootecam.festivals.domain.festival.dto.KeySetPageResponse;
 import com.wootecam.festivals.domain.festival.service.FestivalService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,10 +45,11 @@ public class FestivalController {
 
     @GetMapping
     public ApiResponse<KeySetPageResponse<FestivalListResponse>> getFestivals(
-            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorTime,
+            @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") int pageSize) {
-        KeySetPageResponse<FestivalListResponse> response = festivalService.getFestivals(cursor, pageSize);
-
+        KeySetPageResponse<FestivalListResponse> response = festivalService.getFestivals(cursorTime, cursorId,
+                pageSize);
         return ApiResponse.of(response);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalController.java
@@ -3,6 +3,8 @@ package com.wootecam.festivals.domain.festival.controller;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequest;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponse;
 import com.wootecam.festivals.domain.festival.dto.FestivalDetailResponse;
+import com.wootecam.festivals.domain.festival.dto.FestivalListResponse;
+import com.wootecam.festivals.domain.festival.dto.KeySetPageResponse;
 import com.wootecam.festivals.domain.festival.service.FestivalService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import jakarta.validation.Valid;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,5 +39,14 @@ public class FestivalController {
     public ApiResponse<FestivalDetailResponse> getFestival(@PathVariable Long festivalId) {
         FestivalDetailResponse responseDto = festivalService.getFestivalDetail(festivalId);
         return ApiResponse.of(responseDto);
+    }
+
+    @GetMapping
+    public ApiResponse<KeySetPageResponse<FestivalListResponse>> getFestivals(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int pageSize) {
+        KeySetPageResponse<FestivalListResponse> response = festivalService.getFestivals(cursor, pageSize);
+
+        return ApiResponse.of(response);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/Cursor.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/Cursor.java
@@ -1,0 +1,6 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import java.time.LocalDateTime;
+
+public record Cursor(LocalDateTime time, Long id) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalAdminResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalAdminResponse.java
@@ -1,0 +1,15 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import com.wootecam.festivals.domain.member.entity.Member;
+
+public record FestivalAdminResponse(Long adminId,
+                                    String name,
+                                    String email,
+                                    String profileImg) {
+    public static FestivalAdminResponse from(Member member) {
+        return new FestivalAdminResponse(member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getProfileImg());
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequest.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequest.java
@@ -8,6 +8,9 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record FestivalCreateRequest(
+        @NotNull(message = "주최 단체 정보는 필수입니다.")
+        Long adminId,
+
         @NotBlank(message = "축제 제목은 필수입니다.")
         @Size(min = 1, max = 100, message = "축제 제목은 1자 이상 100자 이하여야 합니다.")
         String title,

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalDetailResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalDetailResponse.java
@@ -5,6 +5,7 @@ import com.wootecam.festivals.domain.festival.entity.FestivalStatus;
 import java.time.LocalDateTime;
 
 public record FestivalDetailResponse(Long festivalId,
+                                     Long adminId,
                                      String title,
                                      String description,
                                      LocalDateTime startTime,
@@ -14,6 +15,7 @@ public record FestivalDetailResponse(Long festivalId,
     public static FestivalDetailResponse from(Festival festival) {
         return new FestivalDetailResponse(
                 festival.getId(),
+                festival.getAdmin().getId(),
                 festival.getTitle(),
                 festival.getDescription(),
                 festival.getStartTime(),

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalListResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalListResponse.java
@@ -2,7 +2,6 @@ package com.wootecam.festivals.domain.festival.dto;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.entity.FestivalStatus;
-import com.wootecam.festivals.domain.organization.dto.OrganizationResponse;
 import java.time.LocalDateTime;
 
 public record FestivalListResponse(Long festivalId,
@@ -10,7 +9,7 @@ public record FestivalListResponse(Long festivalId,
                                    LocalDateTime startTime,
                                    LocalDateTime endTime,
                                    FestivalStatus festivalStatus,
-                                   OrganizationResponse organization) {
+                                   FestivalAdminResponse admin) {
 
     public static FestivalListResponse from(Festival festival) {
         return new FestivalListResponse(festival.getId(),
@@ -18,7 +17,7 @@ public record FestivalListResponse(Long festivalId,
                 festival.getStartTime(),
                 festival.getEndTime(),
                 festival.getFestivalStatus(),
-                OrganizationResponse.from(festival.getOrganization())
+                FestivalAdminResponse.from(festival.getAdmin())
         );
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalListResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/FestivalListResponse.java
@@ -1,0 +1,24 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.entity.FestivalStatus;
+import com.wootecam.festivals.domain.organization.dto.OrganizationResponse;
+import java.time.LocalDateTime;
+
+public record FestivalListResponse(Long festivalId,
+                                   String title,
+                                   LocalDateTime startTime,
+                                   LocalDateTime endTime,
+                                   FestivalStatus festivalStatus,
+                                   OrganizationResponse organization) {
+
+    public static FestivalListResponse from(Festival festival) {
+        return new FestivalListResponse(festival.getId(),
+                festival.getTitle(),
+                festival.getStartTime(),
+                festival.getEndTime(),
+                festival.getFestivalStatus(),
+                OrganizationResponse.from(festival.getOrganization())
+        );
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/KeySetPageResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/KeySetPageResponse.java
@@ -3,6 +3,12 @@ package com.wootecam.festivals.domain.festival.dto;
 import java.util.List;
 
 public record KeySetPageResponse<T>(List<T> content,
-                                    Long nextCursor,
+                                    Cursor cursor,
                                     boolean hasNext) {
+
+    public KeySetPageResponse {
+        if (!hasNext) {
+            cursor = null;
+        }
+    }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/KeySetPageResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/KeySetPageResponse.java
@@ -1,0 +1,8 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import java.util.List;
+
+public record KeySetPageResponse<T>(List<T> content,
+                                    Long nextCursor,
+                                    boolean hasNext) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -56,7 +56,7 @@ public class Festival extends BaseEntity {
 
     @NotNull
     @Enumerated(value = EnumType.STRING)
-    private FestivalStatus festivalStatus = FestivalStatus.DRAFT; //기본 상태를 비공개로 설정.
+    private FestivalStatus festivalStatus;
 
     @NotNull
     private boolean isDeleted;
@@ -69,6 +69,7 @@ public class Festival extends BaseEntity {
         this.description = Objects.requireNonNull(description);
         this.startTime = Objects.requireNonNull(startTime);
         this.endTime = Objects.requireNonNull(endTime);
+        this.festivalStatus = festivalStatus == null ? FestivalStatus.DRAFT : festivalStatus;
         this.isDeleted = false;
         validate();
     }

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -1,13 +1,17 @@
 package com.wootecam.festivals.domain.festival.entity;
 
+import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.global.audit.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -30,6 +34,11 @@ public class Festival extends BaseEntity {
     private Long id;
 
     @NotNull
+    @JoinColumn(name = "admin_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member admin;
+
+    @NotNull
     @Column(nullable = false, length = TITLE_MAX_LENGTH)
     private String title;
 
@@ -47,18 +56,20 @@ public class Festival extends BaseEntity {
 
     @NotNull
     @Enumerated(value = EnumType.STRING)
-    private FestivalStatus festivalStatus = FestivalStatus.DRAFT; //기본 상태를 비공개로 설정.
+    private FestivalStatus festivalStatus;
 
     @NotNull
     private boolean isDeleted;
 
     @Builder
-    private Festival(String title, String description, LocalDateTime startTime,
-                     LocalDateTime endTime) {
+    private Festival(Member admin, String title, String description, LocalDateTime startTime,
+                     LocalDateTime endTime, FestivalStatus festivalStatus) {
+        this.admin = Objects.requireNonNull(admin);
         this.title = Objects.requireNonNull(title);
         this.description = Objects.requireNonNull(description);
         this.startTime = Objects.requireNonNull(startTime);
         this.endTime = Objects.requireNonNull(endTime);
+        this.festivalStatus = festivalStatus == null ? FestivalStatus.DRAFT : festivalStatus;
         this.isDeleted = false;
         validate();
     }

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -56,7 +56,7 @@ public class Festival extends BaseEntity {
 
     @NotNull
     @Enumerated(value = EnumType.STRING)
-    private FestivalStatus festivalStatus;
+    private FestivalStatus festivalStatus = FestivalStatus.DRAFT; //기본 상태를 비공개로 설정.
 
     @NotNull
     private boolean isDeleted;
@@ -69,7 +69,6 @@ public class Festival extends BaseEntity {
         this.description = Objects.requireNonNull(description);
         this.startTime = Objects.requireNonNull(startTime);
         this.endTime = Objects.requireNonNull(endTime);
-        this.festivalStatus = festivalStatus == null ? FestivalStatus.DRAFT : festivalStatus;
         this.isDeleted = false;
         validate();
     }

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -1,13 +1,27 @@
 package com.wootecam.festivals.domain.festival.repository;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
     @Query("SELECT f FROM Festival f WHERE f.id = :id AND f.isDeleted = false")
     @Override
     Optional<Festival> findById(Long id);
+
+    @Query("SELECT f FROM Festival f JOIN FETCH f.organization " +
+            "WHERE f.id < :cursor AND f.isDeleted = false " +
+            "AND f.festivalStatus != 'DRAFT' AND f.startTime > :now " +
+            "ORDER BY f.startTime ASC, f.id DESC")
+    List<Festival> findUpcomingFestivalsBeforeCursor(
+            @Param("cursor") Long cursor,
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -16,12 +16,14 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
     Optional<Festival> findById(Long id);
 
     @Query("SELECT f FROM Festival f JOIN FETCH f.organization " +
-            "WHERE f.id < :cursor AND f.isDeleted = false " +
-            "AND f.festivalStatus != 'DRAFT' AND f.startTime > :now " +
+            "WHERE (f.startTime > :startTime OR (f.startTime = :startTime AND f.id < :id)) " +
+            "AND f.isDeleted = false " +
+            "AND f.festivalStatus != 'DRAFT' " +
+            "AND f.startTime > :now " +
             "ORDER BY f.startTime ASC, f.id DESC")
-    List<Festival> findUpcomingFestivalsBeforeCursor(
-            @Param("cursor") Long cursor,
-            @Param("now") LocalDateTime now,
-            Pageable pageable
+    List<Festival> findUpcomingFestivalsBeforeCursor(@Param("startTime") LocalDateTime startTime,
+                                                     @Param("id") Long id,
+                                                     @Param("now") LocalDateTime now,
+                                                     Pageable pageable
     );
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -15,7 +15,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
     @Override
     Optional<Festival> findById(Long id);
 
-    @Query("SELECT f FROM Festival f JOIN FETCH f.organization " +
+    @Query("SELECT f FROM Festival f JOIN FETCH f.admin " +
             "WHERE (f.startTime > :startTime OR (f.startTime = :startTime AND f.id < :id)) " +
             "AND f.isDeleted = false " +
             "AND f.festivalStatus != 'DRAFT' " +

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
@@ -70,12 +70,14 @@ public class FestivalService {
                 .map(FestivalListResponse::from)
                 .toList();
 
-        Cursor nextCursor = null;
-        if (hasNext && !pageContent.isEmpty()) {
+        LocalDateTime nextCursorTime = null;
+        Long nextCursorId = null;
+        if (hasNext) {
             Festival lastFestival = pageContent.get(pageContent.size() - 1);
-            nextCursor = new Cursor(lastFestival.getStartTime(), lastFestival.getId());
+            nextCursorTime = lastFestival.getStartTime();
+            nextCursorId = lastFestival.getId();
         }
 
-        return new KeySetPageResponse<>(responses, nextCursor, hasNext);
+        return new KeySetPageResponse<>(responses, new Cursor(nextCursorTime, nextCursorId), hasNext);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/util/FestivalFactory.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/util/FestivalFactory.java
@@ -2,6 +2,10 @@ package com.wootecam.festivals.domain.festival.util;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequest;
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.global.exception.GlobalErrorCode;
+import com.wootecam.festivals.global.exception.type.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,8 +13,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class FestivalFactory {
 
+    private final MemberRepository memberRepository;
+
     public Festival createFromDto(FestivalCreateRequest request) {
+        Member admin = memberRepository.findById(request.adminId())
+                .orElseThrow(() -> new ApiException(GlobalErrorCode.INVALID_REQUEST_PARAMETER, "유효하지 않는 조직입니다."));
+
         return Festival.builder()
+                .admin(admin)
                 .title(request.title())
                 .description(request.description())
                 .startTime(request.startTime())

--- a/src/main/java/com/wootecam/festivals/domain/festival/util/FestivalFactory.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/util/FestivalFactory.java
@@ -17,7 +17,7 @@ public class FestivalFactory {
 
     public Festival createFromDto(FestivalCreateRequest request) {
         Member admin = memberRepository.findById(request.adminId())
-                .orElseThrow(() -> new ApiException(GlobalErrorCode.INVALID_REQUEST_PARAMETER, "유효하지 않는 조직입니다."));
+                .orElseThrow(() -> new ApiException(GlobalErrorCode.INVALID_REQUEST_PARAMETER, "유효하지 않는 멤버입니다."));
 
         return Festival.builder()
                 .admin(admin)

--- a/src/test/java/com/wootecam/festivals/docs/utils/RestDocsSupport.java
+++ b/src/test/java/com/wootecam/festivals/docs/utils/RestDocsSupport.java
@@ -10,6 +10,7 @@ import com.wootecam.festivals.global.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -44,16 +45,20 @@ public abstract class RestDocsSupport {
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper);
+
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
                 .setControllerAdvice(new GlobalExceptionHandler(), new ApiExceptionHandler())
                 .apply(documentationConfiguration(provider))
                 .alwaysDo(MockMvcResultHandlers.print())
                 .alwaysDo(restDocs)
+                .setMessageConverters(converter)
                 .addFilter(new CharacterEncodingFilter("UTF-8", true))
                 .build();
 
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     protected abstract Object initController();

--- a/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.domain.festival.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -8,18 +9,25 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wootecam.festivals.docs.utils.RestDocsSupport;
+import com.wootecam.festivals.domain.festival.dto.Cursor;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequest;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponse;
 import com.wootecam.festivals.domain.festival.dto.FestivalDetailResponse;
+import com.wootecam.festivals.domain.festival.dto.FestivalListResponse;
+import com.wootecam.festivals.domain.festival.dto.KeySetPageResponse;
 import com.wootecam.festivals.domain.festival.entity.FestivalStatus;
 import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
 import com.wootecam.festivals.domain.festival.service.FestivalService;
+import com.wootecam.festivals.domain.organization.dto.OrganizationResponse;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,6 +59,7 @@ class FestivalControllerTest extends RestDocsSupport {
     @BeforeEach
     void setUp() {
         validRequestDto = new FestivalCreateRequest(
+                1L,
                 "Summer Music Festival",
                 "A vibrant music festival featuring various artists",
                 LocalDateTime.now().plusDays(30),
@@ -75,6 +84,8 @@ class FestivalControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.festivalId").value(expectedFestivalId))
                 .andDo(restDocs.document(
                         requestFields(
+                                fieldWithPath("organizationId").type(JsonFieldType.NUMBER)
+                                        .description("주최 단체 ID"),
                                 fieldWithPath("title").type(JsonFieldType.STRING)
                                         .description("축제 제목"),
                                 fieldWithPath("description").type(JsonFieldType.STRING)
@@ -96,6 +107,7 @@ class FestivalControllerTest extends RestDocsSupport {
     void createFestival_InvalidInput() throws Exception {
         // Given
         FestivalCreateRequest invalidRequestDto = new FestivalCreateRequest(
+                null,
                 "",
                 "Description",
                 LocalDateTime.now().minusDays(1),
@@ -109,6 +121,8 @@ class FestivalControllerTest extends RestDocsSupport {
                 .andExpect(status().isBadRequest())
                 .andDo(restDocs.document(
                         requestFields(
+                                fieldWithPath("organizationId").type(JsonFieldType.NULL)
+                                        .description("주최 단체 ID (필수)"),
                                 fieldWithPath("title").type(JsonFieldType.STRING)
                                         .description("축제 제목 (필수, 공백 불가)"),
                                 fieldWithPath("description").type(JsonFieldType.STRING)
@@ -135,6 +149,7 @@ class FestivalControllerTest extends RestDocsSupport {
         LocalDateTime now = LocalDateTime.now();
         FestivalDetailResponse responseDto = new FestivalDetailResponse(
                 festivalId,
+                1L,
                 "Summer Music Festival",
                 "A vibrant music festival featuring various artists",
                 now.plusDays(30),
@@ -156,10 +171,11 @@ class FestivalControllerTest extends RestDocsSupport {
                         ),
                         responseFields(
                                 fieldWithPath("data.festivalId").type(JsonFieldType.NUMBER).description("축제 ID"),
+                                fieldWithPath("data.organizationId").type(JsonFieldType.NUMBER).description("주최 단체 ID"),
                                 fieldWithPath("data.title").type(JsonFieldType.STRING).description("축제 제목"),
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("축제 설명"),
-                                fieldWithPath("data.startTime").type(JsonFieldType.ARRAY).description("축제 시작 시간"),
-                                fieldWithPath("data.endTime").type(JsonFieldType.ARRAY).description("축제 종료 시간"),
+                                fieldWithPath("data.startTime").type(JsonFieldType.STRING).description("축제 시작 시간"),
+                                fieldWithPath("data.endTime").type(JsonFieldType.STRING).description("축제 종료 시간"),
                                 fieldWithPath("data.festivalStatus").type(JsonFieldType.STRING).description("축제 상태")
                         )
                 ));
@@ -188,5 +204,111 @@ class FestivalControllerTest extends RestDocsSupport {
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("페이지네이션된 축제 목록 조회 API")
+    void getFestivals() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        List<FestivalListResponse> festivalResponses = List.of(
+                new FestivalListResponse(1L, "축제1", now, now.plusDays(7), FestivalStatus.PUBLISHED,
+                        new OrganizationResponse(1L, "기관1", "detail1", "img1")),
+                new FestivalListResponse(2L, "축제2", now.plusDays(1), now.plusDays(8), FestivalStatus.PUBLISHED,
+                        new OrganizationResponse(2L, "기관2", "detail2", "img2"))
+        );
+        Cursor nextCursor = new Cursor(now.plusDays(1), 2L);
+        KeySetPageResponse<FestivalListResponse> pageResponse = new KeySetPageResponse<>(festivalResponses, nextCursor,
+                true);
+
+        given(festivalService.getFestivals(any(), any(), anyInt())).willReturn(pageResponse);
+
+        // when & then
+        this.mockMvc.perform(get("/api/v1/festivals")
+                        .param("cursorTime", now.toString())
+                        .param("cursorId", "1")
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].festivalId").value(1))
+                .andExpect(jsonPath("$.data.content[1].festivalId").value(2))
+                .andExpect(jsonPath("$.data.cursor.time").value(now.plusDays(1).toString()))
+                .andExpect(jsonPath("$.data.cursor.id").value(2))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("cursorTime").description("다음 페이지 조회를 위한 시간 커서").optional(),
+                                parameterWithName("cursorId").description("다음 페이지 조회를 위한 ID 커서").optional(),
+                                parameterWithName("pageSize").description("페이지 크기").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("data.content[]").type(JsonFieldType.ARRAY).description("축제 목록"),
+                                fieldWithPath("data.content[].festivalId").type(JsonFieldType.NUMBER)
+                                        .description("축제 ID"),
+                                fieldWithPath("data.content[].title").type(JsonFieldType.STRING).description("축제 제목"),
+                                fieldWithPath("data.content[].startTime").type(JsonFieldType.STRING)
+                                        .description("축제 시작 시간"),
+                                fieldWithPath("data.content[].endTime").type(JsonFieldType.STRING)
+                                        .description("축제 종료 시간"),
+                                fieldWithPath("data.content[].festivalStatus").type(JsonFieldType.STRING)
+                                        .description("축제 상태"),
+                                fieldWithPath("data.content[].organization.organizationId").type(JsonFieldType.NUMBER)
+                                        .description("기관 ID"),
+                                fieldWithPath("data.content[].organization.name").type(JsonFieldType.STRING)
+                                        .description("기관 이름"),
+                                fieldWithPath("data.content[].organization.detail").type(JsonFieldType.STRING)
+                                        .description("기관 상세 정보"),
+                                fieldWithPath("data.content[].organization.profileImg").type(JsonFieldType.STRING)
+                                        .description("기관 프로필 이미지"),
+                                fieldWithPath("data.cursor.time").type(JsonFieldType.STRING)
+                                        .description("다음 페이지 시간 커서"),
+                                fieldWithPath("data.cursor.id").type(JsonFieldType.NUMBER).description("다음 페이지 ID 커서"),
+                                fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("마지막 페이지 조회 시 cursor가 null이고 hasNext가 false인 응답을 반환한다.")
+    void getLastPage() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        List<FestivalListResponse> festivalResponses = List.of(
+                new FestivalListResponse(1L, "축제1", now, now.plusDays(7), FestivalStatus.PUBLISHED,
+                        new OrganizationResponse(1L, "기관1", "detail1", "img1"))
+        );
+        KeySetPageResponse<FestivalListResponse> pageResponse = new KeySetPageResponse<>(festivalResponses, null,
+                false);
+
+        given(festivalService.getFestivals(any(), any(), anyInt())).willReturn(pageResponse);
+
+        // when & then
+        this.mockMvc.perform(get("/api/v1/festivals")
+                        .param("cursorTime", now.toString())
+                        .param("cursorId", "1")
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].festivalId").value(1))
+                .andExpect(jsonPath("$.data.cursor").doesNotExist())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("빈 결과를 조회할 경우 빈 content와 null cursor, false hasNext를 반환한다.")
+    void getEmptyResult() throws Exception {
+        // given
+        KeySetPageResponse<FestivalListResponse> pageResponse = new KeySetPageResponse<>(List.of(), null, false);
+
+        given(festivalService.getFestivals(any(), any(), anyInt())).willReturn(pageResponse);
+
+        // when & then
+        this.mockMvc.perform(get("/api/v1/festivals")
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content").isEmpty())
+                .andExpect(jsonPath("$.data.cursor").doesNotExist())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 }

--- a/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wootecam.festivals.docs.utils.RestDocsSupport;
 import com.wootecam.festivals.domain.festival.dto.Cursor;
+import com.wootecam.festivals.domain.festival.dto.FestivalAdminResponse;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateRequest;
 import com.wootecam.festivals.domain.festival.dto.FestivalCreateResponse;
 import com.wootecam.festivals.domain.festival.dto.FestivalDetailResponse;
@@ -24,7 +25,6 @@ import com.wootecam.festivals.domain.festival.dto.KeySetPageResponse;
 import com.wootecam.festivals.domain.festival.entity.FestivalStatus;
 import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
 import com.wootecam.festivals.domain.festival.service.FestivalService;
-import com.wootecam.festivals.domain.organization.dto.OrganizationResponse;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -84,8 +84,8 @@ class FestivalControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.festivalId").value(expectedFestivalId))
                 .andDo(restDocs.document(
                         requestFields(
-                                fieldWithPath("organizationId").type(JsonFieldType.NUMBER)
-                                        .description("주최 단체 ID"),
+                                fieldWithPath("adminId").type(JsonFieldType.NUMBER)
+                                        .description("주최 멤버 ID"),
                                 fieldWithPath("title").type(JsonFieldType.STRING)
                                         .description("축제 제목"),
                                 fieldWithPath("description").type(JsonFieldType.STRING)
@@ -121,8 +121,8 @@ class FestivalControllerTest extends RestDocsSupport {
                 .andExpect(status().isBadRequest())
                 .andDo(restDocs.document(
                         requestFields(
-                                fieldWithPath("organizationId").type(JsonFieldType.NULL)
-                                        .description("주최 단체 ID (필수)"),
+                                fieldWithPath("adminId").type(JsonFieldType.NULL)
+                                        .description("주최 멤버 ID (필수)"),
                                 fieldWithPath("title").type(JsonFieldType.STRING)
                                         .description("축제 제목 (필수, 공백 불가)"),
                                 fieldWithPath("description").type(JsonFieldType.STRING)
@@ -171,7 +171,7 @@ class FestivalControllerTest extends RestDocsSupport {
                         ),
                         responseFields(
                                 fieldWithPath("data.festivalId").type(JsonFieldType.NUMBER).description("축제 ID"),
-                                fieldWithPath("data.organizationId").type(JsonFieldType.NUMBER).description("주최 단체 ID"),
+                                fieldWithPath("data.adminId").type(JsonFieldType.NUMBER).description("주최 멤버 ID"),
                                 fieldWithPath("data.title").type(JsonFieldType.STRING).description("축제 제목"),
                                 fieldWithPath("data.description").type(JsonFieldType.STRING).description("축제 설명"),
                                 fieldWithPath("data.startTime").type(JsonFieldType.STRING).description("축제 시작 시간"),
@@ -213,9 +213,9 @@ class FestivalControllerTest extends RestDocsSupport {
         LocalDateTime now = LocalDateTime.now();
         List<FestivalListResponse> festivalResponses = List.of(
                 new FestivalListResponse(1L, "축제1", now, now.plusDays(7), FestivalStatus.PUBLISHED,
-                        new OrganizationResponse(1L, "기관1", "detail1", "img1")),
+                        new FestivalAdminResponse(1L, "관리자1", "detail1@email.com", "img1")),
                 new FestivalListResponse(2L, "축제2", now.plusDays(1), now.plusDays(8), FestivalStatus.PUBLISHED,
-                        new OrganizationResponse(2L, "기관2", "detail2", "img2"))
+                        new FestivalAdminResponse(2L, "관리자2", "detail2@emil.com", "img2"))
         );
         Cursor nextCursor = new Cursor(now.plusDays(1), 2L);
         KeySetPageResponse<FestivalListResponse> pageResponse = new KeySetPageResponse<>(festivalResponses, nextCursor,
@@ -252,14 +252,14 @@ class FestivalControllerTest extends RestDocsSupport {
                                         .description("축제 종료 시간"),
                                 fieldWithPath("data.content[].festivalStatus").type(JsonFieldType.STRING)
                                         .description("축제 상태"),
-                                fieldWithPath("data.content[].organization.organizationId").type(JsonFieldType.NUMBER)
-                                        .description("기관 ID"),
-                                fieldWithPath("data.content[].organization.name").type(JsonFieldType.STRING)
-                                        .description("기관 이름"),
-                                fieldWithPath("data.content[].organization.detail").type(JsonFieldType.STRING)
-                                        .description("기관 상세 정보"),
-                                fieldWithPath("data.content[].organization.profileImg").type(JsonFieldType.STRING)
-                                        .description("기관 프로필 이미지"),
+                                fieldWithPath("data.content[].admin.adminId").type(JsonFieldType.NUMBER)
+                                        .description("관리자 멤버 ID"),
+                                fieldWithPath("data.content[].admin.name").type(JsonFieldType.STRING)
+                                        .description("관리자 멤버 이름"),
+                                fieldWithPath("data.content[].admin.email").type(JsonFieldType.STRING)
+                                        .description("관리자 이메일"),
+                                fieldWithPath("data.content[].admin.profileImg").type(JsonFieldType.STRING)
+                                        .description("관리자 프로필 이미지"),
                                 fieldWithPath("data.cursor.time").type(JsonFieldType.STRING)
                                         .description("다음 페이지 시간 커서"),
                                 fieldWithPath("data.cursor.id").type(JsonFieldType.NUMBER).description("다음 페이지 ID 커서"),
@@ -275,7 +275,7 @@ class FestivalControllerTest extends RestDocsSupport {
         LocalDateTime now = LocalDateTime.now();
         List<FestivalListResponse> festivalResponses = List.of(
                 new FestivalListResponse(1L, "축제1", now, now.plusDays(7), FestivalStatus.PUBLISHED,
-                        new OrganizationResponse(1L, "기관1", "detail1", "img1"))
+                        new FestivalAdminResponse(1L, "관리자1", "detail1@ed.com", "img1"))
         );
         KeySetPageResponse<FestivalListResponse> pageResponse = new KeySetPageResponse<>(festivalResponses, null,
                 false);

--- a/src/test/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/dto/FestivalCreateRequestTest.java
@@ -33,7 +33,7 @@ class FestivalCreateRequestTest {
     void validDtoShouldPass() {
         LocalDateTime now = LocalDateTime.now();
         FestivalCreateRequest dto = new FestivalCreateRequest(
-                "Summer Festival", "A great summer festival",
+                1L, "Summer Festival", "A great summer festival",
                 now.plusDays(1), now.plusDays(2)
         );
 
@@ -47,7 +47,7 @@ class FestivalCreateRequestTest {
     void invalidDtoShouldFail(String title, String description,
                               LocalDateTime startTime, LocalDateTime endTime, String expectedViolation) {
         FestivalCreateRequest dto = new FestivalCreateRequest(
-                title, description, startTime, endTime
+                1L, title, description, startTime, endTime
         );
 
         var violations = validator.validate(dto);

--- a/src/test/java/com/wootecam/festivals/domain/festival/entity/FestivalTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/entity/FestivalTest.java
@@ -3,6 +3,7 @@ package com.wootecam.festivals.domain.festival.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.wootecam.festivals.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,6 +13,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class FestivalTest {
 
+    private static final Member VALID_ADMIN = Member.builder()
+            .name("test")
+            .email("test")
+            .profileImg("test")
+            .build();
     private static final String VALID_TITLE = "유효한 제목";
     private static final String VALID_DESCRIPTION = "유효한 설명";
     private static final LocalDateTime VALID_START_TIME = LocalDateTime.now().plusDays(1);
@@ -26,6 +32,7 @@ class FestivalTest {
         void createFestivalWithValidData() {
             // Given & When
             Festival festival = Festival.builder()
+                    .admin(VALID_ADMIN)
                     .title(VALID_TITLE)
                     .description(VALID_DESCRIPTION)
                     .startTime(VALID_START_TIME)
@@ -34,6 +41,7 @@ class FestivalTest {
 
             // Then
             assertThat(festival).isNotNull();
+            assertThat(festival.getAdmin()).isEqualTo(VALID_ADMIN);
             assertThat(festival.getTitle()).isEqualTo(VALID_TITLE);
             assertThat(festival.getDescription()).isEqualTo(VALID_DESCRIPTION);
             assertThat(festival.getStartTime()).isEqualTo(VALID_START_TIME);
@@ -59,6 +67,7 @@ class FestivalTest {
             // Given & When & Then
             assertThatThrownBy(() ->
                     Festival.builder()
+                            .admin(VALID_ADMIN)
                             .title("")
                             .description(VALID_DESCRIPTION)
                             .startTime(VALID_START_TIME)
@@ -79,6 +88,7 @@ class FestivalTest {
             // When & Then
             assertThatThrownBy(() ->
                     Festival.builder()
+                            .admin(VALID_ADMIN)
                             .title(tooLongTitle)
                             .description(VALID_DESCRIPTION)
                             .startTime(VALID_START_TIME)
@@ -100,6 +110,7 @@ class FestivalTest {
             // Given & When & Then
             assertThatThrownBy(() ->
                     Festival.builder()
+                            .admin(VALID_ADMIN)
                             .title(VALID_TITLE)
                             .description("")
                             .startTime(VALID_START_TIME)
@@ -120,6 +131,7 @@ class FestivalTest {
             // When & Then
             assertThatThrownBy(() ->
                     Festival.builder()
+                            .admin(VALID_ADMIN)
                             .title(VALID_TITLE)
                             .description(tooLongDescription)
                             .startTime(VALID_START_TIME)
@@ -144,6 +156,7 @@ class FestivalTest {
             // When & Then
             assertThatThrownBy(() ->
                     Festival.builder()
+                            .admin(VALID_ADMIN)
                             .title(VALID_TITLE)
                             .description(VALID_DESCRIPTION)
                             .startTime(invalidStartTime)

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
@@ -109,7 +109,7 @@ class FestivalServiceTest extends SpringBootTestConfig {
             assertThatThrownBy(() -> festivalService.createFestival(requestDto))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_REQUEST_PARAMETER)
-                    .hasMessageContaining("유효하지 않는 조직입니다.");
+                    .hasMessageContaining("유효하지 않는 멤버입니다.");
         }
 
         @Test

--- a/src/test/java/com/wootecam/festivals/domain/festival/stub/FestivalStub.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/stub/FestivalStub.java
@@ -1,20 +1,23 @@
 package com.wootecam.festivals.domain.festival.stub;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.member.entity.Member;
 import java.time.LocalDateTime;
 
 public class FestivalStub extends Festival {
 
     private final Long id;
+    private final Member admin;
     private final String title;
     private final String description;
     private final LocalDateTime startTime;
     private final LocalDateTime endTime;
 
-    private FestivalStub(Long id, String title, String description,
+    private FestivalStub(Long id, Member admin, String title, String description,
                          LocalDateTime startTime, LocalDateTime endTime) {
         super();
         this.id = id;
+        this.admin = admin;
         this.title = title;
         this.description = description;
         this.startTime = startTime;
@@ -22,19 +25,19 @@ public class FestivalStub extends Festival {
     }
 
     public static FestivalStub createValidFestival(Long id) {
-        return new FestivalStub(id,
+        return new FestivalStub(id, Member.builder().name("test").email("test@test.com").profileImg("").build(),
                 "Test Festival", "Test Description",
                 LocalDateTime.now(), LocalDateTime.now().plusDays(7));
     }
 
     public static FestivalStub createFestivalWithNullId() {
-        return new FestivalStub(null,
+        return new FestivalStub(null, Member.builder().name("test").email("test@test.com").profileImg("").build(),
                 "Test Festival", "Test Description",
                 LocalDateTime.now(), LocalDateTime.now().plusDays(7));
     }
 
     public static FestivalStub createFestivalWithTime(LocalDateTime festivalStartTime, LocalDateTime festivalEndTime) {
-        return new FestivalStub(null,
+        return new FestivalStub(null, Member.builder().name("test").email("test@test.com").profileImg("").build(),
                 "Test Festival", "Test Description",
                 festivalStartTime, festivalEndTime);
     }
@@ -42,6 +45,11 @@ public class FestivalStub extends Festival {
     @Override
     public Long getId() {
         return this.id;
+    }
+
+    @Override
+    public Member getAdmin() {
+        return admin;
     }
 
     @Override

--- a/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.domain.organization.repository.OrganizationRepository;
 import com.wootecam.festivals.domain.ticket.dto.TicketCreateRequest;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
@@ -30,10 +33,18 @@ class TicketServiceTest {
     @Autowired
     private FestivalRepository festivalRepository;
 
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
     @BeforeEach
     void setUp() {
         TestDBCleaner.clear(ticketRepository);
         TestDBCleaner.clear(festivalRepository);
+        TestDBCleaner.clear(organizationRepository);
+        TestDBCleaner.clear(memberRepository);
     }
 
     @Nested
@@ -46,7 +57,14 @@ class TicketServiceTest {
             // Given
             LocalDateTime now = LocalDateTime.now();
 
+            Member admin = Member.builder()
+                    .name("관리자")
+                    .profileImg("기관 이미지")
+                    .email("eamil@emai.com")
+                    .build();
+
             Festival festival = Festival.builder()
+                    .admin(admin)
                     .title("페스티벌 이름")
                     .description("페스티벌 설명")
                     .startTime(now)
@@ -57,6 +75,7 @@ class TicketServiceTest {
                     now.plusDays(1), now.plusDays(6), now.plusDays(10));
 
             // When
+            Member saveAdmin = memberRepository.save(admin);
             Festival saveFestival = festivalRepository.save(festival);
 
             Festival findFestival = festivalRepository.findById(saveFestival.getId()).get();
@@ -65,7 +84,8 @@ class TicketServiceTest {
             assertAll(
                     () -> assertThat(ticketService.createTicket(saveFestival.getId(), ticketCreateRequest)).isNotNull(),
                     () -> assertThat(ticketRepository.findAll()).hasSize(1),
-                    () -> assertThat(findFestival.getId()).isEqualTo(saveFestival.getId())
+                    () -> assertThat(findFestival.getId()).isEqualTo(saveFestival.getId()),
+                    () -> assertThat(findFestival.getAdmin().getId()).isEqualTo(saveAdmin.getId())
             );
         }
 

--- a/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
@@ -8,7 +8,6 @@ import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
-import com.wootecam.festivals.domain.organization.repository.OrganizationRepository;
 import com.wootecam.festivals.domain.ticket.dto.TicketCreateRequest;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
@@ -32,10 +31,6 @@ class TicketServiceTest {
 
     @Autowired
     private FestivalRepository festivalRepository;
-
-    @Autowired
-    private OrganizationRepository organizationRepository;
-
     @Autowired
     private MemberRepository memberRepository;
 
@@ -43,7 +38,6 @@ class TicketServiceTest {
     void setUp() {
         TestDBCleaner.clear(ticketRepository);
         TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(organizationRepository);
         TestDBCleaner.clear(memberRepository);
     }
 


### PR DESCRIPTION
## 📄 작업 설명
- 페스티벌을 페이지네이션을 통해 조회할 수 있습니다.
- 페이지네이션은 키셋기반으로 하였습니다.
- 기본 순서는 startTime순이고 같은 startTime일 때 id로 진행하게 됩니다.
- Organization이 제거됨에 따라 Member를 Admin으로 가지고 있도록 변경됐습니다.
## 🚨 관련 이슈
closes #45

## 🌈 작업 상황
- 현재 시관 관련 내용을 LocalDateTime으로 받고 있는데 도메인 특성상 시:분 까지만 필요하다고 생각해 변경 예정입니다.
## 📌 기타
