### PR TITLE
feat#62/페스티벌 상세 페이지에서 티켓 종류 조회 구현

### DIFF
--- a/src/docs/asciidoc/api/domain/ticket/Ticket.adoc
+++ b/src/docs/asciidoc/api/domain/ticket/Ticket.adoc
@@ -12,3 +12,14 @@ include::{snippets}/ticket-controller-test/create-ticket/request-fields.adoc[]
 
 include::{snippets}/ticket-controller-test/create-ticket/http-response.adoc[]
 include::{snippets}/ticket-controller-test/create-ticket/response-fields-data.adoc[]
+
+=== 티켓 조회 API
+
+==== HTTP Request
+
+include::{snippets}/ticket-controller-test/get-tickets/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/ticket-controller-test/get-tickets/http-response.adoc[]
+include::{snippets}/ticket-controller-test/get-tickets/response-fields-data.adoc[]

--- a/src/main/java/com/wootecam/festivals/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/controller/TicketController.java
@@ -2,12 +2,14 @@ package com.wootecam.festivals.domain.ticket.controller;
 
 import com.wootecam.festivals.domain.ticket.dto.TicketCreateRequest;
 import com.wootecam.festivals.domain.ticket.dto.TicketIdResponse;
+import com.wootecam.festivals.domain.ticket.dto.TicketListResponse;
 import com.wootecam.festivals.domain.ticket.service.TicketService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +43,17 @@ public class TicketController {
         TicketIdResponse response = ticketService.createTicket(festivalId, request);
         log.debug("티켓 생성 완료 - 축제 ID: {}, 티켓 ID: {}", festivalId, response.ticketId());
         return ApiResponse.of(response);
+    }
+
+    /**
+     * 티켓 목록 조회 API
+     *
+     * @param festivalId
+     * @return
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    public ApiResponse<TicketListResponse> getTickets(@PathVariable Long festivalId) {
+        return ApiResponse.of(ticketService.getTickets(festivalId));
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/controller/TicketController.java
@@ -54,6 +54,9 @@ public class TicketController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     public ApiResponse<TicketListResponse> getTickets(@PathVariable Long festivalId) {
-        return ApiResponse.of(ticketService.getTickets(festivalId));
+        log.debug("티켓 목록 조회 요청 - 축제 ID: {}", festivalId);
+        TicketListResponse tickets = ticketService.getTickets(festivalId);
+        log.debug("조회된 티켓 목록: {}", tickets);
+        return ApiResponse.of(tickets);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketListResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketListResponse.java
@@ -1,0 +1,6 @@
+package com.wootecam.festivals.domain.ticket.dto;
+
+import java.util.List;
+
+public record TicketListResponse(Long festivalId, List<TicketResponse> tickets) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketResponse.java
@@ -1,0 +1,14 @@
+package com.wootecam.festivals.domain.ticket.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link com.wootecam.festivals.domain.ticket.entity.Ticket}
+ */
+public record TicketResponse(Long id,
+                             String name, String detail,
+                             Long price, int quantity, int remainStock,
+                             LocalDateTime startSaleTime, LocalDateTime endSaleTime,
+                             LocalDateTime refundEndTime,
+                             LocalDateTime createdAt, LocalDateTime updatedAt) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
@@ -13,10 +13,14 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     @Override
     Optional<Ticket> findById(Long ticketId);
 
-    @Query("SELECT new com.wootecam.festivals.domain.ticket.dto.TicketResponse(t.id, t.name, t.detail, t.price, t.quantity, "
-            +
-            "ts.remainStock, t.startSaleTime, t.endSaleTime, t.refundEndTime, t.createdAt, t.updatedAt) " +
-            "FROM Ticket t LEFT JOIN TicketStock ts ON t.id = ts.ticket.id " +
-            "WHERE t.festival.id = :festivalId AND t.isDeleted = false")
+    @Query("""
+            SELECT new com.wootecam.festivals.domain.ticket.dto.TicketResponse(
+                t.id, t.name, t.detail, t.price, t.quantity, ts.remainStock, 
+                t.startSaleTime, t.endSaleTime, t.refundEndTime, t.createdAt, t.updatedAt
+            ) 
+            FROM Ticket t 
+            LEFT JOIN TicketStock ts ON t.id = ts.ticket.id 
+            WHERE t.festival.id = :festivalId AND t.isDeleted = false
+            """)
     List<TicketResponse> findTicketsByFestivalIdWithRemainStock(Long festivalId);
 }

--- a/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
@@ -1,6 +1,8 @@
 package com.wootecam.festivals.domain.ticket.repository;
 
+import com.wootecam.festivals.domain.ticket.dto.TicketResponse;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +12,11 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     @Query("SELECT t FROM Ticket t WHERE t.id = :ticketId AND t.isDeleted = false")
     @Override
     Optional<Ticket> findById(Long ticketId);
+
+    @Query("SELECT new com.wootecam.festivals.domain.ticket.dto.TicketResponse(t.id, t.name, t.detail, t.price, t.quantity, "
+            +
+            "ts.remainStock, t.startSaleTime, t.endSaleTime, t.refundEndTime, t.createdAt, t.updatedAt) " +
+            "FROM Ticket t LEFT JOIN TicketStock ts ON t.id = ts.ticket.id " +
+            "WHERE t.festival.id = :festivalId AND t.isDeleted = false")
+    List<TicketResponse> findTicketsByFestivalIdWithRemainStock(Long festivalId);
 }

--- a/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
@@ -5,10 +5,13 @@ import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.ticket.dto.TicketCreateRequest;
 import com.wootecam.festivals.domain.ticket.dto.TicketIdResponse;
+import com.wootecam.festivals.domain.ticket.dto.TicketListResponse;
+import com.wootecam.festivals.domain.ticket.dto.TicketResponse;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -53,5 +56,26 @@ public class TicketService {
         log.debug("티켓 생성 완료 - 티켓 ID: {}", response.ticketId());
 
         return response;
+    }
+
+    /**
+     * 축제 ID에 해당하는 티켓 목록 조회
+     *
+     * @param festivalId 축제 ID
+     * @return 티켓 목록 응답 DTO
+     */
+    public TicketListResponse getTickets(Long festivalId) {
+        log.debug("티켓 목록 조회 요청 - 축제 ID: {}", festivalId);
+        Festival festival = festivalRepository.findById(festivalId)
+                .orElseThrow(() -> {
+                    log.warn("축제를 찾을 수 없음 - 축제 ID: {}", festivalId);
+                    return new ApiException(FestivalErrorCode.FESTIVAL_NOT_FOUND);
+                });
+
+        List<TicketResponse> ticketsByFestivalIdWithRemainStock =
+                ticketRepository.findTicketsByFestivalIdWithRemainStock(festival.getId());
+        log.debug("티켓 목록: {}", ticketsByFestivalIdWithRemainStock);
+
+        return new TicketListResponse(festival.getId(), ticketsByFestivalIdWithRemainStock);
     }
 }

--- a/src/test/java/com/wootecam/festivals/domain/ticket/controller/TicketControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/controller/TicketControllerTest.java
@@ -16,6 +16,7 @@ import static com.wootecam.festivals.domain.ticket.utils.TicketValidConstant.TIC
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -29,8 +30,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.wootecam.festivals.docs.utils.RestDocsSupport;
 import com.wootecam.festivals.domain.ticket.dto.TicketCreateRequest;
 import com.wootecam.festivals.domain.ticket.dto.TicketIdResponse;
+import com.wootecam.festivals.domain.ticket.dto.TicketListResponse;
+import com.wootecam.festivals.domain.ticket.dto.TicketResponse;
 import com.wootecam.festivals.domain.ticket.service.TicketService;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,33 +53,14 @@ import org.springframework.test.context.ActiveProfiles;
 class TicketControllerTest extends RestDocsSupport {
 
     @MockBean
-    private TicketService ticketService;
+    public TicketService ticketService;
 
-    private static Stream<Arguments> provideInvalidTicketCreateRequests() {
-        LocalDateTime now = LocalDateTime.now();
-        return Stream.of(
-                Arguments.of("a".repeat(101), "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
-                        TICKET_NAME_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "a".repeat(1001), 10000L, 100, now, now.plusDays(1), now.plusDays(1),
-                        TICKET_DETAIL_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "티켓 상세", -1L, 100, now, now.plusDays(1), now.plusDays(1),
-                        TICKET_PRICE_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "티켓 상세", 10000000000L, 100, now, now.plusDays(1), now.plusDays(1),
-                        TICKET_PRICE_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "티켓 상세", 10000L, 0, now, now.plusDays(1), now.plusDays(1),
-                        TICKET_QUANTITY_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "티켓 상세", 10000L, 100001, now, now.plusDays(1), now.plusDays(1),
-                        TICKET_QUANTITY_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "티켓 상세", 10000L, 100, now, now.minusDays(1), now.plusDays(1),
-                        TICKET_END_TIME_VALID_MESSAGE),
-                Arguments.of("티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(1), now.minusDays(1),
-                        TICKET_REFUND_TIME_VALID_MESSAGE)
-        );
-    }
+    private TicketController ticketController;
 
     @Override
     protected Object initController() {
-        return new TicketController(ticketService);
+        ticketController = new TicketController(ticketService);
+        return ticketController;
     }
 
     @Test
@@ -141,6 +127,7 @@ class TicketControllerTest extends RestDocsSupport {
                                     LocalDateTime startSaleTime,
                                     LocalDateTime endSaleTime, LocalDateTime refundEndTime, String errorMessage)
             throws Exception {
+        // given
         TicketCreateRequest ticketCreateRequest = new TicketCreateRequest(name, detail, price, quantity, startSaleTime,
                 endSaleTime, refundEndTime);
 
@@ -149,5 +136,73 @@ class TicketControllerTest extends RestDocsSupport {
                         .content(objectMapper.writeValueAsString(ticketCreateRequest)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(errorMessage));
+    }
+
+    private static Stream<Arguments> provideInvalidTicketCreateRequests() {
+        LocalDateTime now = LocalDateTime.now();
+        return Stream.of(
+                Arguments.of("a".repeat(101), "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
+                        TICKET_NAME_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "a".repeat(1001), 10000L, 100, now, now.plusDays(1), now.plusDays(1),
+                        TICKET_DETAIL_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "티켓 상세", -1L, 100, now, now.plusDays(1), now.plusDays(1),
+                        TICKET_PRICE_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "티켓 상세", 10000000000L, 100, now, now.plusDays(1), now.plusDays(1),
+                        TICKET_PRICE_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "티켓 상세", 10000L, 0, now, now.plusDays(1), now.plusDays(1),
+                        TICKET_QUANTITY_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "티켓 상세", 10000L, 100001, now, now.plusDays(1), now.plusDays(1),
+                        TICKET_QUANTITY_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "티켓 상세", 10000L, 100, now, now.minusDays(1), now.plusDays(1),
+                        TICKET_END_TIME_VALID_MESSAGE),
+                Arguments.of("티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(1), now.minusDays(1),
+                        TICKET_REFUND_TIME_VALID_MESSAGE)
+        );
+    }
+
+    @Test
+    @DisplayName("티켓 목록 조회 API")
+    void getTickets() throws Exception {
+        List<TicketResponse> tickets = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            tickets.add(new TicketResponse((long) i, "티켓 이름" + i, "티켓 설명" + i,
+                    1000L, 100, 100,
+                    LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2), LocalDateTime.now().plusDays(3),
+                    LocalDateTime.now(), LocalDateTime.now()));
+        }
+
+        given(ticketService.getTickets(anyLong())).willReturn(new TicketListResponse(1L, tickets));
+
+        mockMvc.perform(get("/api/v1/festivals/{festivalId}/tickets", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.tickets").isArray())
+                .andExpect(jsonPath("$.data.festivalId").value(1L))
+                .andExpect(jsonPath("$.data.tickets[0].id").value(1L))
+                .andExpect(jsonPath("$.data.tickets[0].name").value("티켓 이름1"))
+                .andExpect(jsonPath("$.data.tickets[0].detail").value("티켓 설명1"))
+                .andExpect(jsonPath("$.data.tickets[0].price").value(1000L))
+                .andExpect(jsonPath("$.data.tickets[0].quantity").value(100))
+                .andDo(restDocs.document(
+                        pathParameters(
+                                parameterWithName("festivalId").description("축제 ID")
+                        ),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("festivalId").type(JsonFieldType.NUMBER).description("축제 ID"),
+                                fieldWithPath("tickets").type(JsonFieldType.ARRAY).description("티켓 목록")
+                        ).andWithPrefix("tickets[].",
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("티켓 ID"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("티켓 이름"),
+                                fieldWithPath("detail").type(JsonFieldType.STRING).description("티켓 설명"),
+                                fieldWithPath("price").type(JsonFieldType.NUMBER).description("티켓 가격"),
+                                fieldWithPath("quantity").type(JsonFieldType.NUMBER).description("티켓 수량"),
+                                fieldWithPath("remainStock").type(JsonFieldType.NUMBER).description("남은 티켓 수량"),
+                                fieldWithPath("startSaleTime").type(JsonFieldType.STRING).description("티켓 판매 시작 시간"),
+                                fieldWithPath("endSaleTime").type(JsonFieldType.STRING).description("티켓 판매 종료 시간"),
+                                fieldWithPath("refundEndTime").type(JsonFieldType.STRING).description("티켓 환불 종료 시간"),
+                                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 시간"),
+                                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("수정 시간")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
@@ -10,6 +10,9 @@ import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.ticket.dto.TicketCreateRequest;
 import com.wootecam.festivals.domain.ticket.dto.TicketIdResponse;
+import com.wootecam.festivals.domain.ticket.dto.TicketListResponse;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
@@ -99,6 +102,76 @@ class TicketServiceTest {
 
             // When, Then
             assertThatThrownBy(() -> ticketService.createTicket(festivalId, ticketCreateRequest))
+                    .isInstanceOf(ApiException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTickets 메소드는")
+    class Describe_getTickets {
+
+        @Test
+        @DisplayName("페스티벌의 티켓 목록을 반환한다.")
+        void it_returns_ticket_list_of_festival() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+
+            Member admin = Member.builder()
+                    .name("관리자")
+                    .profileImg("기관 이미지")
+                    .email("eamil@emai.com")
+                    .build();
+
+            Festival festival = Festival.builder()
+                    .admin(admin)
+                    .title("페스티벌 이름")
+                    .description("페스티벌 설명")
+                    .startTime(now)
+                    .endTime(now.plusDays(7))
+                    .build();
+
+            memberRepository.save(admin);
+            Festival saveFestival = festivalRepository.save(festival);
+
+            for (int i = 0; i < 5; i++) {
+                Ticket ticket = Ticket.builder()
+                        .festival(saveFestival)
+                        .name("티켓 이름" + i)
+                        .detail("티켓 설명" + i)
+                        .price(10000L)
+                        .quantity(100)
+                        .startSaleTime(now.plusDays(1))
+                        .endSaleTime(now.plusDays(6))
+                        .refundEndTime(now.plusDays(10))
+                        .build();
+
+                TicketStock ticketStock = TicketStock.builder()
+                        .ticket(ticket)
+                        .remainStock(100)
+                        .build();
+
+                ticketRepository.save(ticket);
+                ticketStockRepository.save(ticketStock);
+            }
+
+            // When
+            TicketListResponse ticketListResponse = ticketService.getTickets(saveFestival.getId());
+
+            // Then
+            assertAll(
+                    () -> assertThat(ticketListResponse).isNotNull(),
+                    () -> assertThat(ticketListResponse.tickets()).hasSize(5)
+            );
+        }
+
+        @Test
+        @DisplayName("페스티벌을 찾을 수 없으면 예외를 던진다.")
+        void it_throws_festival_not_found_exception_when_festival_is_not_found() {
+            // Given
+            Long festivalId = 1L;
+
+            // When, Then
+            assertThatThrownBy(() -> ticketService.getTickets(festivalId))
                     .isInstanceOf(ApiException.class);
         }
     }


### PR DESCRIPTION
## 📄 작업 설명
페스티벌 상세 페이지에서 티켓들을 볼 수 있는 기능을 구현했어요. Dto Projection을 통해 연관관계를 만들지 않고 조회 했어요.
화면 맞춤 조회 로직이 맞을 거 같아서 해당 방식으로 구현 했습니다.
확인부탁드릴께요 !

## 🚨 관련 이슈
closes #62 

## 🌈 작업 상황
- TicketController 조회 API 구현
- TicketService 조회 로직 구현
- TicketRepository Projection 구현
- 응답 및 화면 구성을 위한 DTO 구현

## 📌 기타
