### PR TITLE
Feat#54/체크인 로직 구현

### DIFF
--- a/src/docs/asciidoc/api/domain/checkin/Checkin.adoc
+++ b/src/docs/asciidoc/api/domain/checkin/Checkin.adoc
@@ -1,0 +1,54 @@
+[[Checkin]]
+== Checkin API
+
+=== 체크인 업데이트 API
+
+==== HTTP Request
+
+include::{snippets}/checkin-controller-test/update-checked-in/http-request.adoc[]
+include::{snippets}/checkin-controller-test/update-checked-in/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/checkin-controller-test/update-checked-in/http-response.adoc[]
+include::{snippets}/checkin-controller-test/update-checked-in/response-fields.adoc[]
+
+=== 체크인 업데이트 API (실패 케이스 - 체크인 정보 없음)
+
+==== HTTP Request
+
+include::{snippets}/checkin-controller-test/fail_update-checked-in/http-request.adoc[]
+include::{snippets}/checkin-controller-test/fail_update-checked-in/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/checkin-controller-test/fail_update-checked-in/http-response.adoc[]
+include::{snippets}/checkin-controller-test/fail_update-checked-in/response-fields.adoc[]
+
+=== 체크인 업데이트 API (실패 케이스 - 이미 체크인됨)
+
+==== HTTP Request
+
+include::{snippets}/checkin-controller-test/fail_update-checked-in/http-request.adoc[]
+include::{snippets}/checkin-controller-test/fail_update-checked-in/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/checkin-controller-test/fail_update-checked-in/http-response.adoc[]
+include::{snippets}/checkin-controller-test/fail_update-checked-in/response-fields.adoc[]
+
+==== 설명
+
+체크인 API는 특정 축제의 특정 티켓에 대한 체크인 상태를 업데이트합니다.
+
+- `festivalId`: 축제 ID
+- `ticketId`: 티켓 ID
+- `checkinId`: 체크인 ID
+
+성공적으로 체크인이 업데이트되면 200 OK 상태 코드와 함께 응답 본문의 `data` 필드는 `null`을 반환합니다.
+
+실패 케이스:
+1. 체크인 정보를 찾을 수 없는 경우: 404 Not Found 상태 코드를 반환합니다.
+2. 이미 체크인된 경우: 400 Bad Request 상태 코드를 반환합니다.
+
+실패 시 응답에는 `errorCode` 와 `message` 필드가 포함되어 오류의 원인을 설명합니다.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -25,6 +25,9 @@ include::api/domain/ticket/Ticket.adoc[]
 [[Purchase-API]]
 include::api/domain/purchase/purchase.adoc[]
 
+[[Checkin-API]]
+include::api/domain/checkin/Checkin.adoc[]
+
 [[Enums]]
 == Enums
 

--- a/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
@@ -1,0 +1,30 @@
+package com.wootecam.festivals.domain.checkin.controller;
+
+import com.wootecam.festivals.domain.checkin.service.CheckinService;
+import com.wootecam.festivals.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/festivals/{festivalId}/tickets/{ticketId}/checkins")
+@RequiredArgsConstructor
+public class CheckinController {
+
+    private final CheckinService checkinService;
+
+    /**
+     * 체크인 정보를 체크인 되었음으로 업데이트 합니다.
+     * @param checkinId 조회할 체크인의 식별자
+     * @return null
+     */
+    @PatchMapping("/{checkinId}")
+    public ApiResponse<Void> updateCheckedIn(@PathVariable Long checkinId) {
+        checkinService.updateCheckedIn(checkinId);
+        return ApiResponse.of(null);
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
@@ -25,7 +25,7 @@ public class CheckinController {
     @PatchMapping("/{checkinId}")
     public ApiResponse<Void> updateCheckedIn(@PathVariable Long checkinId) {
         log.debug("체크인 업데이트 처리 요청 - 체크인 ID: {}", checkinId);
-        checkinService.updateCheckedIn(checkinId);
+        checkinService.completeCheckin(checkinId);
         log.debug("체크인 업데이트 처리 완료 - 체크인 ID: {}", checkinId);
         return ApiResponse.of(null);
     }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
@@ -24,7 +24,9 @@ public class CheckinController {
      */
     @PatchMapping("/{checkinId}")
     public ApiResponse<Void> updateCheckedIn(@PathVariable Long checkinId) {
+        log.debug("체크인 업데이트 처리 요청 - 체크인 ID: {}", checkinId);
         checkinService.updateCheckedIn(checkinId);
+        log.debug("체크인 업데이트 처리 완료 - 체크인 ID: {}", checkinId);
         return ApiResponse.of(null);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/controller/CheckinController.java
@@ -27,6 +27,6 @@ public class CheckinController {
         log.debug("체크인 업데이트 처리 요청 - 체크인 ID: {}", checkinId);
         checkinService.completeCheckin(checkinId);
         log.debug("체크인 업데이트 처리 완료 - 체크인 ID: {}", checkinId);
-        return ApiResponse.of(null);
+        return ApiResponse.empty();
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/dto/CheckinIdDto.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/dto/CheckinIdDto.java
@@ -1,0 +1,4 @@
+package com.wootecam.festivals.domain.checkin.dto;
+
+public record CheckinIdDto(Long checkinId) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/checkin/dto/CheckinIdResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/dto/CheckinIdResponse.java
@@ -1,4 +1,4 @@
 package com.wootecam.festivals.domain.checkin.dto;
 
-public record CheckinIdDto(Long checkinId) {
+public record CheckinIdResponse(Long checkinId) {
 }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -15,8 +15,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -48,7 +46,6 @@ public class Checkin extends BaseEntity {
     private Ticket ticket;
 
     @Column(name = "checkin_time")
-    @Version
     private LocalDateTime checkinTime; // 체크인하지 않은 경우 null
 
     @Column(name = "is_checked", nullable = false)

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -22,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "checkin")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Checkin extends BaseEntity {

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -1,11 +1,16 @@
 package com.wootecam.festivals.domain.checkin.entity;
 
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.global.audit.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -24,17 +29,20 @@ public class Checkin extends BaseEntity {
     @Column(name = "checkin_id")
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "festival_id", nullable = false, updatable = false)
     @NotNull
-    @Column(name = "festival_id", nullable = false)
-    private Long festivalId;
+    private Festival festival;
 
+    @ManyToOne
+    @Column(name = "member_id", nullable = false, updatable = false)
     @NotNull
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    private Member member;
 
+    @ManyToOne
     @NotNull
-    @Column(name = "ticket_id", nullable = false)
-    private Long ticketId;
+    @Column(name = "ticket_id", nullable = false, updatable = false)
+    private Ticket ticket;
 
     @Column(name = "checkin_time")
     private LocalDateTime checkinTime; // 체크인하지 않은 경우 null
@@ -44,10 +52,10 @@ public class Checkin extends BaseEntity {
     private boolean isChecked;
 
     @Builder
-    private Checkin(Long festivalId, Long memberId, Long ticketId) {
-        this.festivalId = Objects.requireNonNull(festivalId);
-        this.memberId = Objects.requireNonNull(memberId);
-        this.ticketId = Objects.requireNonNull(ticketId);
+    private Checkin(Festival festival, Member member, Ticket ticket) {
+        this.festival = Objects.requireNonNull(festival);
+        this.member = Objects.requireNonNull(member);
+        this.ticket = Objects.requireNonNull(ticket);
         this.checkinTime = null;
         this.isChecked = false;
     }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -1,9 +1,11 @@
 package com.wootecam.festivals.domain.checkin.entity;
 
+import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.global.audit.BaseEntity;
+import com.wootecam.festivals.global.exception.type.ApiException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -61,7 +63,16 @@ public class Checkin extends BaseEntity {
     }
 
     public void updateCheckedIn() {
+        // 이미 체크인한 경우 에러 발생
+        if (isCheckedIn()) {
+            throw new ApiException(CheckinErrorCode.ALREADY_CHECKED_IN);
+        }
+
         isChecked = true;
         checkinTime = LocalDateTime.now();
+    }
+
+    public boolean isCheckedIn() {
+        return isChecked && checkinTime != null;
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -1,0 +1,54 @@
+package com.wootecam.festivals.domain.checkin.entity;
+
+import com.wootecam.festivals.global.audit.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Checkin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "checkin_id")
+    private Long id;
+
+    @NotNull
+    @Column(name = "festival_id", nullable = false)
+    private Long festivalId;
+
+    @NotNull
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @NotNull
+    @Column(name = "ticket_id", nullable = false)
+    private Long ticketId;
+
+    @Column(name = "checkin_time")
+    private LocalDateTime checkinTime; // 체크인하지 않은 경우 null
+
+    @NotNull
+    @Column(name = "is_checked", nullable = false)
+    private boolean isChecked;
+
+    @Builder
+    private Checkin(Long festivalId, Long memberId, Long ticketId) {
+        this.festivalId = Objects.requireNonNull(festivalId);
+        this.memberId = Objects.requireNonNull(memberId);
+        this.ticketId = Objects.requireNonNull(ticketId);
+        this.checkinTime = null;
+        this.isChecked = false;
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -8,12 +8,14 @@ import com.wootecam.festivals.global.audit.BaseEntity;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -33,25 +35,22 @@ public class Checkin extends BaseEntity {
     @Column(name = "checkin_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id", nullable = false, updatable = false)
-    @NotNull
     private Festival festival;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
-    @NotNull
     private Member member;
 
-    @ManyToOne
-    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id", nullable = false, updatable = false)
     private Ticket ticket;
 
     @Column(name = "checkin_time")
+    @Version
     private LocalDateTime checkinTime; // 체크인하지 않은 경우 null
 
-    @NotNull
     @Column(name = "is_checked", nullable = false)
     private boolean isChecked;
 

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -37,13 +37,13 @@ public class Checkin extends BaseEntity {
     private Festival festival;
 
     @ManyToOne
-    @Column(name = "member_id", nullable = false, updatable = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
     @NotNull
     private Member member;
 
     @ManyToOne
     @NotNull
-    @Column(name = "ticket_id", nullable = false, updatable = false)
+    @JoinColumn(name = "ticket_id", nullable = false, updatable = false)
     private Ticket ticket;
 
     @Column(name = "checkin_time")

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -51,4 +51,9 @@ public class Checkin extends BaseEntity {
         this.checkinTime = null;
         this.isChecked = false;
     }
+
+    public void updateCheckedIn() {
+        isChecked = true;
+        checkinTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/entity/Checkin.java
@@ -54,8 +54,8 @@ public class Checkin extends BaseEntity {
     private boolean isChecked;
 
     @Builder
-    private Checkin(Festival festival, Member member, Ticket ticket) {
-        this.festival = Objects.requireNonNull(festival);
+    private Checkin(Member member, Ticket ticket) {
+        this.festival = Objects.requireNonNull(ticket.getFestival());
         this.member = Objects.requireNonNull(member);
         this.ticket = Objects.requireNonNull(ticket);
         this.checkinTime = null;

--- a/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum CheckinErrorCode implements ErrorCode, EnumType {
     CHECKIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CI-C-0001", "체크인 기록이 존재하지 않습니다."),
+    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "CI-C-0002", "이미 체크인 되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum CheckinErrorCode implements ErrorCode, EnumType {
     CHECKIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CI-C-0001", "체크인 기록이 존재하지 않습니다."),
     ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "CI-C-0002", "이미 체크인 되었습니다."),
+    ALREADY_SAVED_CHECKIN(HttpStatus.CONFLICT, "CI-C-0003", "이미 저장된 체크인 기록이 존재합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
@@ -1,0 +1,33 @@
+package com.wootecam.festivals.domain.checkin.exception;
+
+import com.wootecam.festivals.global.docs.EnumType;
+import com.wootecam.festivals.global.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CheckinErrorCode implements ErrorCode, EnumType {
+    CHECKIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CI-C-0001", "체크인 기록이 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    CheckinErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+
+    @Override
+    public String getName() {
+        return name();
+    }
+
+    @Override
+    public String getDescription() {
+        return httpStatus + ": " + code + " - " + message;
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/exception/CheckinErrorCode.java
@@ -7,9 +7,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum CheckinErrorCode implements ErrorCode, EnumType {
-    CHECKIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CI-C-0001", "체크인 기록이 존재하지 않습니다."),
-    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "CI-C-0002", "이미 체크인 되었습니다."),
-    ALREADY_SAVED_CHECKIN(HttpStatus.CONFLICT, "CI-C-0003", "이미 저장된 체크인 기록이 존재합니다.")
+    CHECKIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CI-0001", "체크인 기록이 존재하지 않습니다."),
+    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "CI-0002", "이미 체크인 되었습니다."),
+    ALREADY_SAVED_CHECKIN(HttpStatus.CONFLICT, "CI-0003", "이미 저장된 체크인 기록이 존재합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wootecam/festivals/domain/checkin/repository/CheckinRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/repository/CheckinRepository.java
@@ -1,0 +1,10 @@
+package com.wootecam.festivals.domain.checkin.repository;
+
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheckinRepository extends JpaRepository<Checkin, Long> {
+
+    Optional<Checkin> findByMemberIdAndFestivalIdAndTicketId(Long memberId, Long festivalId, Long ticketId);
+}

--- a/src/main/java/com/wootecam/festivals/domain/checkin/repository/CheckinRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/repository/CheckinRepository.java
@@ -3,8 +3,13 @@ package com.wootecam.festivals.domain.checkin.repository;
 import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CheckinRepository extends JpaRepository<Checkin, Long> {
 
-    Optional<Checkin> findByMemberIdAndFestivalIdAndTicketId(Long memberId, Long festivalId, Long ticketId);
+    @Query("""
+            SELECT c FROM Checkin c 
+            WHERE c.member.id = :memberId AND c.ticket.id = :ticketId
+            """)
+    Optional<Checkin> findByMemberIdAndTicketId(Long memberId, Long ticketId);
 }

--- a/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
@@ -23,7 +23,7 @@ public class CheckinService {
     private final TicketRepository ticketRepository;
 
     @Transactional
-    public Long saveCheckin(Long memberId, Long ticketId) {
+    public Long createPendingCheckin(Long memberId, Long ticketId) {
         Member member = memberRepository.getReferenceById(memberId);
         Ticket ticket = ticketRepository.getReferenceById(ticketId);
         
@@ -43,7 +43,7 @@ public class CheckinService {
     }
 
     @Transactional
-    public void updateCheckedIn(Long checkinId) {
+    public void completeCheckin(Long checkinId) {
         Checkin checkin = checkinRepository.findById(checkinId)
                 .orElseThrow(() -> new ApiException(CheckinErrorCode.CHECKIN_NOT_FOUND));
 

--- a/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
@@ -1,5 +1,6 @@
 package com.wootecam.festivals.domain.checkin.service;
 
+import com.wootecam.festivals.domain.checkin.dto.CheckinIdResponse;
 import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
 import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
@@ -23,7 +24,7 @@ public class CheckinService {
     private final TicketRepository ticketRepository;
 
     @Transactional
-    public Long createPendingCheckin(Long memberId, Long ticketId) {
+    public CheckinIdResponse createPendingCheckin(Long memberId, Long ticketId) {
         Member member = memberRepository.getReferenceById(memberId);
         Ticket ticket = ticketRepository.getReferenceById(ticketId);
         
@@ -39,7 +40,7 @@ public class CheckinService {
                 .build());
 
         log.info("체크인 정보 저장: memberId={}, ticketId={}", memberId, ticketId);
-        return savedCheckin.getId();
+        return new CheckinIdResponse(savedCheckin.getId());
     }
 
     @Transactional

--- a/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
@@ -3,6 +3,12 @@ package com.wootecam.festivals.domain.checkin.service;
 import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
 import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +19,23 @@ import org.springframework.stereotype.Service;
 public class CheckinService {
 
     private final CheckinRepository checkinRepository;
+    private final MemberRepository memberRepository;
+    private final FestivalRepository festivalRepository;
+    private final TicketRepository ticketRepository;
+
+    @Transactional
+    public Long saveCheckin(Long memberId, Long festivalId, Long ticketId) {
+        Member member = memberRepository.getReferenceById(memberId);
+        Festival festival = festivalRepository.getReferenceById(festivalId);
+        Ticket ticket = ticketRepository.getReferenceById(ticketId);
+
+        return checkinRepository.save(Checkin.builder()
+                .member(member)
+                .festival(festival)
+                .ticket(ticket)
+                .build())
+                .getId();
+    }
 
     @Transactional
     public void updateCheckedIn(Long memberId, Long festivalId, Long ticketId) {

--- a/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
@@ -1,0 +1,24 @@
+package com.wootecam.festivals.domain.checkin.service;
+
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
+import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CheckinService {
+
+    private final CheckinRepository checkinRepository;
+
+    @Transactional
+    public void updateCheckedIn(Long memberId, Long festivalId, Long ticketId) {
+        Checkin checkin = checkinRepository.findByMemberIdAndFestivalIdAndTicketId(memberId, festivalId, ticketId)
+                .orElseThrow(() -> new ApiException(CheckinErrorCode.CHECKIN_NOT_FOUND));
+
+        checkin.updateCheckedIn();
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
+++ b/src/main/java/com/wootecam/festivals/domain/checkin/service/CheckinService.java
@@ -3,8 +3,6 @@ package com.wootecam.festivals.domain.checkin.service;
 import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
 import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
-import com.wootecam.festivals.domain.festival.entity.Festival;
-import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
@@ -12,36 +10,45 @@ import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CheckinService {
 
     private final CheckinRepository checkinRepository;
     private final MemberRepository memberRepository;
-    private final FestivalRepository festivalRepository;
     private final TicketRepository ticketRepository;
 
     @Transactional
-    public Long saveCheckin(Long memberId, Long festivalId, Long ticketId) {
+    public Long saveCheckin(Long memberId, Long ticketId) {
         Member member = memberRepository.getReferenceById(memberId);
-        Festival festival = festivalRepository.getReferenceById(festivalId);
         Ticket ticket = ticketRepository.getReferenceById(ticketId);
+        
+        checkinRepository.findByMemberIdAndTicketId(memberId, ticketId)
+                .ifPresent(checkin -> {
+                    log.error("이미 저장된 체크인 정보가 존재합니다. memberId={}, ticketId={}", memberId, ticketId);
+                    throw new ApiException(CheckinErrorCode.ALREADY_SAVED_CHECKIN);
+                });
 
-        return checkinRepository.save(Checkin.builder()
+        Checkin savedCheckin = checkinRepository.save(Checkin.builder()
                 .member(member)
-                .festival(festival)
                 .ticket(ticket)
-                .build())
-                .getId();
+                .build());
+
+        log.info("체크인 정보 저장: memberId={}, ticketId={}", memberId, ticketId);
+        return savedCheckin.getId();
     }
 
     @Transactional
-    public void updateCheckedIn(Long memberId, Long festivalId, Long ticketId) {
-        Checkin checkin = checkinRepository.findByMemberIdAndFestivalIdAndTicketId(memberId, festivalId, ticketId)
+    public void updateCheckedIn(Long checkinId) {
+        Checkin checkin = checkinRepository.findById(checkinId)
                 .orElseThrow(() -> new ApiException(CheckinErrorCode.CHECKIN_NOT_FOUND));
 
         checkin.updateCheckedIn();
+
+        log.info("체크인 완료 처리: checkinId={}", checkinId);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/entity/Festival.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "festival")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Festival extends BaseEntity {

--- a/src/main/java/com/wootecam/festivals/domain/member/entity/Member.java
+++ b/src/main/java/com/wootecam/festivals/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member extends BaseEntity {

--- a/src/main/java/com/wootecam/festivals/domain/purchase/controller/PurchaseController.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/controller/PurchaseController.java
@@ -1,12 +1,10 @@
 package com.wootecam.festivals.domain.purchase.controller;
 
-import com.wootecam.festivals.domain.checkin.service.CheckinService;
-import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
-import com.wootecam.festivals.domain.purchase.service.PurchaseService;
+import com.wootecam.festivals.domain.purchase.dto.PurchaseTicketResponse;
+import com.wootecam.festivals.domain.purchase.service.PurchaseFacadeService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import com.wootecam.festivals.global.auth.AuthUser;
 import com.wootecam.festivals.global.auth.Authentication;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -25,8 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PurchaseController {
 
-    private final PurchaseService purchaseService;
-    private final CheckinService checkinService;
+    private final PurchaseFacadeService purchaseFacadeService;
 
     /**
      * 티켓 구매 API
@@ -38,17 +35,14 @@ public class PurchaseController {
      */
     @ResponseStatus(HttpStatus.OK)
     @PostMapping
-    public ApiResponse<PurchaseIdResponse> createPurchase(@PathVariable Long festivalId,
+    public ApiResponse<PurchaseTicketResponse> createPurchase(@PathVariable Long festivalId,
                                                           @PathVariable Long ticketId,
                                                           @AuthUser Authentication authentication) {
-        log.debug("티켓 구매 요청 - 축제 ID: {}, 티켓 ID: {}, 회원 ID: {}", festivalId, ticketId, authentication.memberId());
-        PurchaseIdResponse response = purchaseService.createPurchase(ticketId, authentication.memberId(),
-                LocalDateTime.now());
-        log.debug("티켓 구매 완료 - 구매 ID: {}", response.purchaseId());
 
-        log.debug("체크인 정보 생성 요청 - 티켓 ID: {}, 회원 ID: {}", ticketId, authentication.memberId());
-        Long checkinId = checkinService.createPendingCheckin(authentication.memberId(), ticketId);
-        log.debug("체크인 정보 생성 완료 - 체크인 ID {}", checkinId);
+        log.debug("티켓 구매 요청 - 축제 ID: {}, 티켓 ID: {}, 회원 ID: {}", festivalId, ticketId, authentication.memberId());
+        PurchaseTicketResponse response = purchaseFacadeService.purchaseTicket(authentication.memberId(),
+                festivalId, ticketId);
+        log.debug("티켓 구매 완료 - 구매 ID: {}, 체크인 ID: {}", response.purchaseId(), response.checkinId());
 
         return ApiResponse.of(response);
     }

--- a/src/main/java/com/wootecam/festivals/domain/purchase/controller/PurchaseController.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/controller/PurchaseController.java
@@ -1,5 +1,6 @@
 package com.wootecam.festivals.domain.purchase.controller;
 
+import com.wootecam.festivals.domain.checkin.service.CheckinService;
 import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
 import com.wootecam.festivals.domain.purchase.service.PurchaseService;
 import com.wootecam.festivals.global.api.ApiResponse;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PurchaseController {
 
     private final PurchaseService purchaseService;
+    private final CheckinService checkinService;
 
     /**
      * 티켓 구매 API
@@ -43,6 +45,11 @@ public class PurchaseController {
         PurchaseIdResponse response = purchaseService.createPurchase(ticketId, authentication.memberId(),
                 LocalDateTime.now());
         log.debug("티켓 구매 완료 - 구매 ID: {}", response.purchaseId());
+
+        log.debug("체크인 정보 생성 요청 - 티켓 ID: {}, 회원 ID: {}", ticketId, authentication.memberId());
+        Long checkinId = checkinService.saveCheckin(authentication.memberId(), ticketId);
+        log.debug("체크인 정보 생성 완료 - 체크인 ID {}", checkinId);
+
         return ApiResponse.of(response);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/purchase/controller/PurchaseController.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/controller/PurchaseController.java
@@ -47,7 +47,7 @@ public class PurchaseController {
         log.debug("티켓 구매 완료 - 구매 ID: {}", response.purchaseId());
 
         log.debug("체크인 정보 생성 요청 - 티켓 ID: {}, 회원 ID: {}", ticketId, authentication.memberId());
-        Long checkinId = checkinService.saveCheckin(authentication.memberId(), ticketId);
+        Long checkinId = checkinService.createPendingCheckin(authentication.memberId(), ticketId);
         log.debug("체크인 정보 생성 완료 - 체크인 ID {}", checkinId);
 
         return ApiResponse.of(response);

--- a/src/main/java/com/wootecam/festivals/domain/purchase/dto/PurchaseTicketResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/dto/PurchaseTicketResponse.java
@@ -1,0 +1,4 @@
+package com.wootecam.festivals.domain.purchase.dto;
+
+public record PurchaseTicketResponse(Long purchaseId, Long checkinId) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/purchase/entity/Purchase.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/entity/Purchase.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -20,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "purchase")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Purchase extends BaseEntity {

--- a/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeService.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeService.java
@@ -4,6 +4,7 @@ import com.wootecam.festivals.domain.checkin.dto.CheckinIdResponse;
 import com.wootecam.festivals.domain.checkin.service.CheckinService;
 import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
 import com.wootecam.festivals.domain.purchase.dto.PurchaseTicketResponse;
+import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ public class PurchaseFacadeService {
     private final PurchaseService purchaseService;
     private final CheckinService checkinService;
 
+    @Transactional
     public PurchaseTicketResponse purchaseTicket(Long memberId, Long festivalId, Long ticketId) {
         log.debug("티켓 구매 요청 - 축제 ID: {}, 티켓 ID: {}, 회원 ID: {}", festivalId, ticketId, memberId);
         PurchaseIdResponse purchaseResponse = purchaseService.createPurchase(ticketId, memberId, LocalDateTime.now());

--- a/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeService.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeService.java
@@ -1,0 +1,31 @@
+package com.wootecam.festivals.domain.purchase.service;
+
+import com.wootecam.festivals.domain.checkin.dto.CheckinIdResponse;
+import com.wootecam.festivals.domain.checkin.service.CheckinService;
+import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
+import com.wootecam.festivals.domain.purchase.dto.PurchaseTicketResponse;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PurchaseFacadeService {
+
+    private final PurchaseService purchaseService;
+    private final CheckinService checkinService;
+
+    public PurchaseTicketResponse purchaseTicket(Long memberId, Long festivalId, Long ticketId) {
+        log.debug("티켓 구매 요청 - 축제 ID: {}, 티켓 ID: {}, 회원 ID: {}", festivalId, ticketId, memberId);
+        PurchaseIdResponse purchaseResponse = purchaseService.createPurchase(ticketId, memberId, LocalDateTime.now());
+        log.debug("티켓 구매 완료 - 구매 ID: {}", purchaseResponse.purchaseId());
+
+        log.debug("체크인 정보 생성 요청 - 티켓 ID: {}, 회원 ID: {}", ticketId, memberId);
+        CheckinIdResponse checkinResponse = checkinService.createPendingCheckin(memberId, ticketId);
+        log.debug("체크인 정보 생성 완료 - 체크인 ID {}", checkinResponse);
+
+        return new PurchaseTicketResponse(purchaseResponse.purchaseId(), checkinResponse.checkinId());
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -31,7 +31,6 @@ public class PurchaseService {
     private final PurchaseRepository purchaseRepository;
     private final TicketStockRepository ticketStockRepository;
     private final MemberRepository memberRepository;
-    private final CheckinRepository checkinRepository;
 
     /**
      * 티켓 구매 처리

--- a/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -1,6 +1,5 @@
 package com.wootecam.festivals.domain.purchase.service;
 
-import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
@@ -31,7 +30,6 @@ public class PurchaseService {
     private final PurchaseRepository purchaseRepository;
     private final TicketStockRepository ticketStockRepository;
     private final MemberRepository memberRepository;
-    private final CheckinRepository checkinRepository;
 
     /**
      * 티켓 구매 처리

--- a/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -1,6 +1,5 @@
 package com.wootecam.festivals.domain.purchase.service;
 
-import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
@@ -55,14 +54,6 @@ public class PurchaseService {
         decreaseStock(ticketStock);
         ticketStockRepository.flush(); // 재고 차감 쿼리를 먼저 실행하기 위한 flush
         Purchase newPurchase = purchaseRepository.save(ticket.createPurchase(member));
-
-        // 체크인 정보 생성
-        Checkin checkin = Checkin.builder()
-                .member(member)
-                .ticket(ticket)
-                .build();
-
-        checkinRepository.save(checkin);
 
         log.debug("티켓 구매 완료 - 티켓 ID: {}, 회원 ID: {}, 구매 ID: {}", ticketId, loginMemberId, newPurchase.getId());
         return new PurchaseIdResponse(newPurchase.getId());

--- a/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -1,5 +1,7 @@
 package com.wootecam.festivals.domain.purchase.service;
 
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
@@ -30,6 +32,7 @@ public class PurchaseService {
     private final PurchaseRepository purchaseRepository;
     private final TicketStockRepository ticketStockRepository;
     private final MemberRepository memberRepository;
+    private final CheckinRepository checkinRepository;
 
     /**
      * 티켓 구매 처리
@@ -52,6 +55,14 @@ public class PurchaseService {
         decreaseStock(ticketStock);
         ticketStockRepository.flush(); // 재고 차감 쿼리를 먼저 실행하기 위한 flush
         Purchase newPurchase = purchaseRepository.save(ticket.createPurchase(member));
+
+        // 체크인 정보 생성
+        Checkin checkin = Checkin.builder()
+                .member(member)
+                .ticket(ticket)
+                .build();
+
+        checkinRepository.save(checkin);
 
         log.debug("티켓 구매 완료 - 티켓 ID: {}, 회원 ID: {}, 구매 ID: {}", ticketId, loginMemberId, newPurchase.getId());
         return new PurchaseIdResponse(newPurchase.getId());

--- a/src/main/java/com/wootecam/festivals/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/entity/Ticket.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "ticket")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Ticket extends BaseEntity {

--- a/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -15,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "ticket_stock")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TicketStock extends BaseEntity {

--- a/src/main/java/com/wootecam/festivals/global/api/ApiResponse.java
+++ b/src/main/java/com/wootecam/festivals/global/api/ApiResponse.java
@@ -16,4 +16,8 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> of(T data) {
         return new ApiResponse<>(data);
     }
+
+    public static <T> ApiResponse<T> empty() {
+        return new ApiResponse<>(null);
+    }
 }

--- a/src/test/java/com/wootecam/festivals/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/auth/service/AuthServiceTest.java
@@ -10,7 +10,6 @@ import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
-import com.wootecam.festivals.utils.TestDBCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,7 +27,7 @@ class AuthServiceTest extends SpringBootTestConfig {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(memberRepository);
+        clear();
 
         // given
         memberRepository.save(createMember("email@example.com"));

--- a/src/test/java/com/wootecam/festivals/domain/checkin/controller/CheckinControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/controller/CheckinControllerTest.java
@@ -45,7 +45,7 @@ public class CheckinControllerTest extends RestDocsSupport {
     @DisplayName("체크인 성공 API")
     void updateCheckedIn() throws Exception {
         // given
-        doNothing().when(checkinService).updateCheckedIn(any());
+        doNothing().when(checkinService).completeCheckin(any());
 
         // when & then
         this.mockMvc.perform(patch("/api/v1/festivals/{festivalId}/tickets/{ticketId}/checkins/{checkinId}", 1L, 1L, 1L))
@@ -62,7 +62,7 @@ public class CheckinControllerTest extends RestDocsSupport {
     @DisplayName("체크인 실패 API")
     void fail_updateCheckedIn(ApiException exception) throws Exception {
         // given
-        doThrow(exception).when(checkinService).updateCheckedIn(any());
+        doThrow(exception).when(checkinService).completeCheckin(any());
 
         // when & then
         this.mockMvc.perform(patch("/api/v1/festivals/{festivalId}/tickets/{ticketId}/checkins/{checkinId}", 1L, 1L, 1L))

--- a/src/test/java/com/wootecam/festivals/domain/checkin/controller/CheckinControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/controller/CheckinControllerTest.java
@@ -1,0 +1,77 @@
+package com.wootecam.festivals.domain.checkin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wootecam.festivals.docs.utils.RestDocsSupport;
+import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
+import com.wootecam.festivals.domain.checkin.service.CheckinService;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(CheckinController.class)
+@ActiveProfiles("test")
+public class CheckinControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private CheckinService checkinService;
+
+    @Override
+    protected Object initController() {
+        return new CheckinController(checkinService);
+    }
+
+    static Stream<Arguments> provideException() {
+        return Stream.of(
+                Arguments.of(new ApiException(CheckinErrorCode.CHECKIN_NOT_FOUND)),
+                Arguments.of(new ApiException(CheckinErrorCode.ALREADY_CHECKED_IN))
+        );
+    }
+
+    @Test
+    @DisplayName("체크인 성공 API")
+    void updateCheckedIn() throws Exception {
+        // given
+        doNothing().when(checkinService).updateCheckedIn(any());
+
+        // when & then
+        this.mockMvc.perform(patch("/api/v1/festivals/{festivalId}/tickets/{ticketId}/checkins/{checkinId}", 1L, 1L, 1L))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        PayloadDocumentation.responseFields(
+                                PayloadDocumentation.fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (항상 null)")
+                        )
+                ));
+    }
+
+    @MethodSource("provideException")
+    @ParameterizedTest
+    @DisplayName("체크인 실패 API")
+    void fail_updateCheckedIn(ApiException exception) throws Exception {
+        // given
+        doThrow(exception).when(checkinService).updateCheckedIn(any());
+
+        // when & then
+        this.mockMvc.perform(patch("/api/v1/festivals/{festivalId}/tickets/{ticketId}/checkins/{checkinId}", 1L, 1L, 1L))
+                .andExpect(status().is(exception.getErrorCode().getHttpStatus().value()))
+                .andDo(restDocs.document(
+                        PayloadDocumentation.responseFields(
+                                PayloadDocumentation.fieldWithPath("errorCode").type(JsonFieldType.STRING).description("에러 코드"),
+                                PayloadDocumentation.fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
@@ -19,10 +19,8 @@ import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
-import com.wootecam.festivals.utils.TestDBCleaner;
 import java.time.LocalDateTime;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,10 +51,8 @@ class CheckinServiceTest extends SpringBootTestConfig {
 
     @BeforeEach
     void setup() {
-        TestDBCleaner.clear(checkinRepository);
-        TestDBCleaner.clear(ticketRepository);
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
+
         member = memberRepository.save(Member.builder()
                 .name("test")
                 .email("test@example.com")
@@ -82,15 +78,6 @@ class CheckinServiceTest extends SpringBootTestConfig {
                 .refundEndTime(LocalDateTime.now().plusDays(2))
                 .festival(festival)
                 .build());
-    }
-
-    // fk 이슈 때문에 테스트 종료 후 데이터 초기화
-    @AfterEach
-    void tearDown() {
-        TestDBCleaner.clear(checkinRepository);
-        TestDBCleaner.clear(ticketRepository);
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
     }
 
     @Nested

--- a/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
@@ -1,0 +1,170 @@
+package com.wootecam.festivals.domain.checkin.service;
+
+import static com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode.ALREADY_SAVED_CHECKIN;
+import static com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode.CHECKIN_NOT_FOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
+import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import com.wootecam.festivals.utils.TestDBCleaner;
+import java.time.LocalDateTime;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("CheckinService 통합 테스트")
+class CheckinServiceTest extends SpringBootTestConfig {
+
+    @Autowired
+    private CheckinService checkinService;
+
+    @Autowired
+    private CheckinRepository checkinRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private FestivalRepository festivalRepository;
+
+    private Member member;
+    private Festival festival;
+    private Ticket ticket;
+
+    @BeforeEach
+    void setup() {
+        TestDBCleaner.clear(checkinRepository);
+        TestDBCleaner.clear(ticketRepository);
+        TestDBCleaner.clear(festivalRepository);
+        TestDBCleaner.clear(memberRepository);
+        member = memberRepository.save(Member.builder()
+                .name("test")
+                .email("test@example.com")
+                .profileImg("profile-img")
+                .build()
+        );
+
+        festival = festivalRepository.save(Festival.builder()
+                .admin(member)
+                .title("페스티벌 이름")
+                .description("페스티벌 설명")
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusDays(7))
+                .build());
+
+        ticket = ticketRepository.save(Ticket.builder()
+                .name("Test Ticket")
+                .detail("Test Ticket Detail")
+                .price(10000L)
+                .quantity(100)
+                .startSaleTime(LocalDateTime.now())
+                .endSaleTime(LocalDateTime.now().plusDays(2))
+                .refundEndTime(LocalDateTime.now().plusDays(2))
+                .festival(festival)
+                .build());
+    }
+
+    // fk 이슈 때문에 테스트 종료 후 데이터 초기화
+    @AfterEach
+    void tearDown() {
+        TestDBCleaner.clear(checkinRepository);
+        TestDBCleaner.clear(ticketRepository);
+        TestDBCleaner.clear(festivalRepository);
+        TestDBCleaner.clear(memberRepository);
+    }
+
+    @Nested
+    @DisplayName("saveCheckin 메서드는")
+    class SaveCheckin {
+
+        @Test
+        @DisplayName("체크인 정보를 저장한다")
+        void saveCheckin_Success() {
+            // Given
+            Long savedCheckinId = checkinService.saveCheckin(member.getId(), ticket.getId());
+
+            // When & Then
+            assertAll(
+                    () -> assertNotNull(savedCheckinId),
+                    () -> Assertions.assertThat(checkinRepository.findById(savedCheckinId)).isPresent()
+                            .hasValueSatisfying(checkin -> {
+                                assertAll(
+                                        () -> assertEquals(member.getId(), checkin.getMember().getId()),
+                                        () -> assertEquals(ticket.getFestival().getId(), checkin.getFestival().getId()),
+                                        () -> assertEquals(ticket.getId(), checkin.getTicket().getId())
+                                );
+                            })
+            );
+        }
+
+        @Test
+        @DisplayName("이미 체크인했다면 예외를 던진다")
+        void saveCheckin_AlreadyCheckedIn() {
+            // Given 이미 체크인을 했다면
+            checkinService.saveCheckin(member.getId(), ticket.getId());
+
+            // When & Then
+            assertThatThrownBy(() -> checkinService.saveCheckin(member.getId(), ticket.getId()))
+                    .isInstanceOf(ApiException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ALREADY_SAVED_CHECKIN);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCheckedIn 메서드는")
+    class UpdateCheckedin {
+
+        Long savedCheckinId;
+
+        @BeforeEach
+        void setup() {
+            // 체크인을 이미 한 상태
+            savedCheckinId = checkinService.saveCheckin(member.getId(), ticket.getId());
+        }
+
+        @Test
+        @DisplayName("체크인을 하면 isChecked = True 로 변경된다")
+        void updateCheckedIn_Success() {
+            // Given, When
+            checkinService.updateCheckedIn(savedCheckinId);
+
+            // Then
+            Checkin checkin = checkinRepository.findById(savedCheckinId)
+                    .orElseThrow(() -> new ApiException(CheckinErrorCode.CHECKIN_NOT_FOUND));
+
+            assertTrue(checkin.isChecked());
+        }
+
+        @Test
+        @DisplayName("체크인하지 않은 유저는 체크인을 할 수 없다")
+        void updateCheckedIn_CheckinNotFound() {
+            // Given
+            Long notCheckedInCheckinId = 999L;
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    checkinService.updateCheckedIn(notCheckedInCheckinId))
+                    .hasFieldOrPropertyWithValue("errorCode", CHECKIN_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
@@ -101,7 +101,7 @@ class CheckinServiceTest extends SpringBootTestConfig {
         @DisplayName("체크인 정보를 저장한다")
         void saveCheckin_Success() {
             // Given
-            Long savedCheckinId = checkinService.saveCheckin(member.getId(), ticket.getId());
+            Long savedCheckinId = checkinService.createPendingCheckin(member.getId(), ticket.getId());
 
             // When & Then
             assertAll(
@@ -121,10 +121,10 @@ class CheckinServiceTest extends SpringBootTestConfig {
         @DisplayName("이미 체크인했다면 예외를 던진다")
         void saveCheckin_AlreadyCheckedIn() {
             // Given 이미 체크인을 했다면
-            checkinService.saveCheckin(member.getId(), ticket.getId());
+            checkinService.createPendingCheckin(member.getId(), ticket.getId());
 
             // When & Then
-            assertThatThrownBy(() -> checkinService.saveCheckin(member.getId(), ticket.getId()))
+            assertThatThrownBy(() -> checkinService.createPendingCheckin(member.getId(), ticket.getId()))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ALREADY_SAVED_CHECKIN);
         }
@@ -139,14 +139,14 @@ class CheckinServiceTest extends SpringBootTestConfig {
         @BeforeEach
         void setup() {
             // 체크인을 이미 한 상태
-            savedCheckinId = checkinService.saveCheckin(member.getId(), ticket.getId());
+            savedCheckinId = checkinService.createPendingCheckin(member.getId(), ticket.getId());
         }
 
         @Test
         @DisplayName("체크인을 하면 isChecked = True 로 변경된다")
         void updateCheckedIn_Success() {
             // Given, When
-            checkinService.updateCheckedIn(savedCheckinId);
+            checkinService.completeCheckin(savedCheckinId);
 
             // Then
             Checkin checkin = checkinRepository.findById(savedCheckinId)
@@ -163,7 +163,7 @@ class CheckinServiceTest extends SpringBootTestConfig {
 
             // When & Then
             assertThatThrownBy(() ->
-                    checkinService.updateCheckedIn(notCheckedInCheckinId))
+                    checkinService.completeCheckin(notCheckedInCheckinId))
                     .hasFieldOrPropertyWithValue("errorCode", CHECKIN_NOT_FOUND);
         }
     }

--- a/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.wootecam.festivals.domain.checkin.dto.CheckinIdResponse;
 import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import com.wootecam.festivals.domain.checkin.exception.CheckinErrorCode;
 import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
@@ -88,12 +89,13 @@ class CheckinServiceTest extends SpringBootTestConfig {
         @DisplayName("체크인 정보를 저장한다")
         void saveCheckin_Success() {
             // Given
-            Long savedCheckinId = checkinService.createPendingCheckin(member.getId(), ticket.getId());
+            CheckinIdResponse response = checkinService.createPendingCheckin(member.getId(), ticket.getId());
 
             // When & Then
             assertAll(
-                    () -> assertNotNull(savedCheckinId),
-                    () -> Assertions.assertThat(checkinRepository.findById(savedCheckinId)).isPresent()
+                    () -> assertNotNull(response),
+                    () -> assertNotNull(response.checkinId()),
+                    () -> Assertions.assertThat(checkinRepository.findById(response.checkinId())).isPresent()
                             .hasValueSatisfying(checkin -> {
                                 assertAll(
                                         () -> assertEquals(member.getId(), checkin.getMember().getId()),
@@ -126,7 +128,7 @@ class CheckinServiceTest extends SpringBootTestConfig {
         @BeforeEach
         void setup() {
             // 체크인을 이미 한 상태
-            savedCheckinId = checkinService.createPendingCheckin(member.getId(), ticket.getId());
+            savedCheckinId = checkinService.createPendingCheckin(member.getId(), ticket.getId()).checkinId();
         }
 
         @Test

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalPublicationStatusUpdateServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalPublicationStatusUpdateServiceTest.java
@@ -7,7 +7,7 @@ import com.wootecam.festivals.domain.festival.entity.FestivalProgressStatus;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
-import com.wootecam.festivals.utils.TestDBCleaner;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class FestivalPublicationStatusUpdateServiceTest {
+class FestivalPublicationStatusUpdateServiceTest extends SpringBootTestConfig {
 
     @Autowired
     private FestivalStatusUpdateService festivalStatusUpdateService;
@@ -29,8 +29,7 @@ class FestivalPublicationStatusUpdateServiceTest {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
     }
 
     @Test

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerServiceTest.java
@@ -8,7 +8,7 @@ import com.wootecam.festivals.domain.festival.entity.FestivalProgressStatus;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
-import com.wootecam.festivals.utils.TestDBCleaner;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +22,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @SpringBootTest
 @Nested
 @DisplayName("FestivalSchedulerService 클래스는 ")
-class FestivalSchedulerServiceTest {
+class FestivalSchedulerServiceTest extends SpringBootTestConfig {
 
     @Autowired
     private ThreadPoolTaskScheduler taskScheduler;
@@ -40,8 +40,7 @@ class FestivalSchedulerServiceTest {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
         taskScheduler.getScheduledThreadPoolExecutor().getQueue().clear();
         admin = memberRepository.save(
                 Member.builder()

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
@@ -19,7 +19,6 @@ import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.global.exception.GlobalErrorCode;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
-import com.wootecam.festivals.utils.TestDBCleaner;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -46,8 +45,7 @@ class FestivalServiceTest extends SpringBootTestConfig {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
         admin = memberRepository.save(
                 Member.builder()
                         .name("Test Organization")

--- a/src/test/java/com/wootecam/festivals/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/member/service/MemberServiceTest.java
@@ -14,7 +14,6 @@ import com.wootecam.festivals.domain.member.exception.MemberErrorCode;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
-import com.wootecam.festivals.utils.TestDBCleaner;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +32,7 @@ class MemberServiceTest extends SpringBootTestConfig {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(memberRepository);
+        clear();
     }
 
     @Nested

--- a/src/test/java/com/wootecam/festivals/domain/purchase/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/controller/PurchaseControllerTest.java
@@ -56,7 +56,7 @@ public class PurchaseControllerTest extends RestDocsSupport {
         //given
         given(purchaseService.createPurchase(any(), any(), any()))
                 .willReturn(new PurchaseIdResponse(1L));
-        given(checkinService.saveCheckin(any(), any()))
+        given(checkinService.createPendingCheckin(any(), any()))
                 .willReturn(1L);
 
         //when then

--- a/src/test/java/com/wootecam/festivals/domain/purchase/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/controller/PurchaseControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wootecam.festivals.docs.utils.RestDocsSupport;
+import com.wootecam.festivals.domain.checkin.service.CheckinService;
 import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
 import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
 import com.wootecam.festivals.domain.purchase.service.PurchaseService;
@@ -33,6 +34,9 @@ public class PurchaseControllerTest extends RestDocsSupport {
     @MockBean
     private PurchaseService purchaseService;
 
+    @MockBean
+    private CheckinService checkinService;
+
     static Stream<Arguments> provideException() {
         return Stream.of(
                 Arguments.of(new ApiException(PurchaseErrorCode.INVALID_TICKET_PURCHASE_TIME)),
@@ -43,7 +47,7 @@ public class PurchaseControllerTest extends RestDocsSupport {
 
     @Override
     protected Object initController() {
-        return new PurchaseController(purchaseService);
+        return new PurchaseController(purchaseService, checkinService);
     }
 
     @Test
@@ -52,6 +56,8 @@ public class PurchaseControllerTest extends RestDocsSupport {
         //given
         given(purchaseService.createPurchase(any(), any(), any()))
                 .willReturn(new PurchaseIdResponse(1L));
+        given(checkinService.saveCheckin(any(), any()))
+                .willReturn(1L);
 
         //when then
         this.mockMvc.perform(post("/api/v1/festivals/{festivalId}/tickets/{ticketId}/purchase", 1L, 1L))

--- a/src/test/java/com/wootecam/festivals/domain/purchase/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/controller/PurchaseControllerTest.java
@@ -10,10 +10,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wootecam.festivals.docs.utils.RestDocsSupport;
-import com.wootecam.festivals.domain.checkin.service.CheckinService;
-import com.wootecam.festivals.domain.purchase.dto.PurchaseIdResponse;
+import com.wootecam.festivals.domain.purchase.dto.PurchaseTicketResponse;
 import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
-import com.wootecam.festivals.domain.purchase.service.PurchaseService;
+import com.wootecam.festivals.domain.purchase.service.PurchaseFacadeService;
 import com.wootecam.festivals.domain.ticket.exception.TicketErrorCode;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.util.stream.Stream;
@@ -32,10 +31,7 @@ import org.springframework.test.context.ActiveProfiles;
 public class PurchaseControllerTest extends RestDocsSupport {
 
     @MockBean
-    private PurchaseService purchaseService;
-
-    @MockBean
-    private CheckinService checkinService;
+    private PurchaseFacadeService purchaseFacadeService;
 
     static Stream<Arguments> provideException() {
         return Stream.of(
@@ -47,17 +43,15 @@ public class PurchaseControllerTest extends RestDocsSupport {
 
     @Override
     protected Object initController() {
-        return new PurchaseController(purchaseService, checkinService);
+        return new PurchaseController(purchaseFacadeService);
     }
 
     @Test
     @DisplayName("티켓 구매 성공 API")
     void createTicket() throws Exception {
         //given
-        given(purchaseService.createPurchase(any(), any(), any()))
-                .willReturn(new PurchaseIdResponse(1L));
-        given(checkinService.createPendingCheckin(any(), any()))
-                .willReturn(1L);
+        given(purchaseFacadeService.purchaseTicket(any(), any(), any()))
+                .willReturn(new PurchaseTicketResponse(1L, 1L));
 
         //when then
         this.mockMvc.perform(post("/api/v1/festivals/{festivalId}/tickets/{ticketId}/purchase", 1L, 1L))
@@ -66,7 +60,8 @@ public class PurchaseControllerTest extends RestDocsSupport {
                 .andDo(restDocs.document(
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),
-                                fieldWithPath("purchaseId").type(JsonFieldType.NUMBER).description("생성된 티켓 구매 내역 ID")
+                                fieldWithPath("purchaseId").type(JsonFieldType.NUMBER).description("생성된 티켓 구매 내역 ID"),
+                                fieldWithPath("checkinId").type(JsonFieldType.NUMBER).description("생성된 체크인 내역 ID")
                         )
                 ));
     }
@@ -76,7 +71,7 @@ public class PurchaseControllerTest extends RestDocsSupport {
     @DisplayName("티켓 구매 실패 API")
     void fail_createTicket(ApiException exception) throws Exception {
         //given
-        given(purchaseService.createPurchase(any(), any(), any())).willThrow(exception);
+        given(purchaseFacadeService.purchaseTicket(any(), any(), any())).willThrow(exception);
 
         //when then
         this.mockMvc.perform(post("/api/v1/festivals/{festivalId}/tickets/{ticketId}/purchase", 1L, 1L))

--- a/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
@@ -39,6 +41,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
     private final TicketRepository ticketRepository;
     private final TicketStockRepository ticketStockRepository;
     private final PurchaseRepository purchaseRepository;
+    private final CheckinRepository checkinRepository;
 
     private LocalDateTime ticketSaleStartTime = LocalDateTime.now();
     private Festival festival;
@@ -48,19 +51,21 @@ class PurchaseServiceTest extends SpringBootTestConfig {
     public PurchaseServiceTest(PurchaseService purchaseService, TicketRepository ticketRepository,
                                FestivalRepository festivalRepository,
                                TicketStockRepository ticketStockRepository, MemberRepository memberRepository,
-                               PurchaseRepository purchaseRepository) {
+                               PurchaseRepository purchaseRepository, CheckinRepository checkinRepository) {
         this.purchaseService = purchaseService;
         this.memberRepository = memberRepository;
         this.festivalRepository = festivalRepository;
         this.ticketRepository = ticketRepository;
         this.ticketStockRepository = ticketStockRepository;
         this.purchaseRepository = purchaseRepository;
+        this.checkinRepository = checkinRepository;
     }
 
     @BeforeEach
     void setUp() {
         TestDBCleaner.clear(purchaseRepository);
         TestDBCleaner.clear(ticketStockRepository);
+        TestDBCleaner.clear(checkinRepository);
         TestDBCleaner.clear(ticketRepository);
         TestDBCleaner.clear(festivalRepository);
         TestDBCleaner.clear(memberRepository);
@@ -103,7 +108,9 @@ class PurchaseServiceTest extends SpringBootTestConfig {
                     () -> assertThat(ticketStockRepository.findByTicket(ticket)).isPresent()
                             .get()
                             .extracting(TicketStock::getRemainStock)
-                            .isEqualTo(ticket.getQuantity() - 1)
+                            .isEqualTo(ticket.getQuantity() - 1),
+                    () -> assertThat(checkinRepository.findByMemberIdAndTicketId(member.getId(), ticket.getId())).isPresent()
+                            .get().extracting(Checkin::isCheckedIn).isEqualTo(false)
             );
         }
 

--- a/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.wootecam.festivals.domain.checkin.entity.Checkin;
 import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
@@ -108,9 +107,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
                     () -> assertThat(ticketStockRepository.findByTicket(ticket)).isPresent()
                             .get()
                             .extracting(TicketStock::getRemainStock)
-                            .isEqualTo(ticket.getQuantity() - 1),
-                    () -> assertThat(checkinRepository.findByMemberIdAndTicketId(member.getId(), ticket.getId())).isPresent()
-                            .get().extracting(Checkin::isCheckedIn).isEqualTo(false)
+                            .isEqualTo(ticket.getQuantity() - 1)
             );
         }
 

--- a/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
@@ -24,7 +24,6 @@ import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
-import com.wootecam.festivals.utils.TestDBCleaner;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +39,6 @@ class PurchaseServiceTest extends SpringBootTestConfig {
     private final TicketRepository ticketRepository;
     private final TicketStockRepository ticketStockRepository;
     private final PurchaseRepository purchaseRepository;
-    private final CheckinRepository checkinRepository;
 
     private LocalDateTime ticketSaleStartTime = LocalDateTime.now();
     private Festival festival;
@@ -57,17 +55,11 @@ class PurchaseServiceTest extends SpringBootTestConfig {
         this.ticketRepository = ticketRepository;
         this.ticketStockRepository = ticketStockRepository;
         this.purchaseRepository = purchaseRepository;
-        this.checkinRepository = checkinRepository;
     }
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(purchaseRepository);
-        TestDBCleaner.clear(ticketStockRepository);
-        TestDBCleaner.clear(checkinRepository);
-        TestDBCleaner.clear(ticketRepository);
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
 
         Member admin = memberRepository.save(createMember("admin", "admin@test.com"));
         festival = festivalRepository.save(createFestival(admin, "Test Festival", "Test Festival Detail",

--- a/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
@@ -16,7 +16,7 @@ import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
-import com.wootecam.festivals.utils.TestDBCleaner;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class TicketServiceTest {
+class TicketServiceTest extends SpringBootTestConfig {
 
     @Autowired
     private TicketService ticketService;
@@ -36,6 +36,7 @@ class TicketServiceTest {
 
     @Autowired
     private FestivalRepository festivalRepository;
+
     @Autowired
     private MemberRepository memberRepository;
 
@@ -44,10 +45,7 @@ class TicketServiceTest {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(ticketStockRepository);
-        TestDBCleaner.clear(ticketRepository);
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
     }
 
     @Nested

--- a/src/test/java/com/wootecam/festivals/utils/SpringBootTestConfig.java
+++ b/src/test/java/com/wootecam/festivals/utils/SpringBootTestConfig.java
@@ -1,9 +1,54 @@
 package com.wootecam.festivals.utils;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class SpringBootTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    public void clear() {
+        transactionTemplate.execute(status -> {
+            disableConstraints();
+            try {
+                truncateTables();
+            } finally {
+                enableConstraints();
+            }
+            return null;
+        });
+    }
+
+    private void disableConstraints() {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+    }
+
+    private void enableConstraints() {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private void truncateTables() {
+        List<Class<?>> entities = entityManager.getMetamodel().getEntities().stream()
+                .map(type -> type.getJavaType())
+                .filter(clazz -> clazz.isAnnotationPresent(Table.class))
+                .collect(Collectors.toList());
+
+        for (Class<?> entity : entities) {
+            String tableName = entity.getAnnotation(Table.class).name();
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+    }
 }

--- a/src/test/java/com/wootecam/festivals/utils/TestDBCleaner.java
+++ b/src/test/java/com/wootecam/festivals/utils/TestDBCleaner.java
@@ -1,9 +1,0 @@
-package com.wootecam.festivals.utils;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public class TestDBCleaner {
-    public static void clear(JpaRepository jpaRepository) {
-        jpaRepository.deleteAll();
-    }
-}


### PR DESCRIPTION
## 📄 작업 설명
- 유저가 티켓으로 행사에 `체크인` 하는 로직 구현
- 유저가 티켓을 구매했을 때 체크인 상태가 false 인 체크인을 생성하는 로직 구현
- Checkin 엔티티는 `Member`, `Festival`, `Ticket` 3가지에 의존을 하고있어요. 그 중에서도 축제는 테이블에 festivalId 를 추가해서 index 로 활용하기 위함이지만 사실 Ticket 에 이미 정보가 들어있긴 합니다. 그래서 인자를 Festival 정보 없이 받도록 구현했어요!

## 🚨 관련 이슈
closes #54 

## 🌈 작업 상황
- Checkin 엔티티에 이미 체크인이 되었다면 에러를 던지는 로직을 추가
- CheckinService 에 체크인 생성, 체크인을 isChecked=true 로 바꾸는 로직을 추가 
- 테스트 코드와 명세서 작성

## 📌 기타
논의하고 싶은게 있습니다! 유저가 티켓을 구매할 경우에 구매 정보 `purchase` 와 체크인 정보 `checkin` 이 생겨야합니다. 그래서 티켓 구매할 때 체크인 로직이 같이 들어가야하는데 의존 관계를 어떻게 할지 고민을 좀 했었어요!

1. PurchaseService 가 CheckinService 를 의존하도록한다.
2. PurchaseSerivce 가 CheckinRepository 를 의존하도록한다.
3. ✅ PurchaseController 가 CheckinService 를 의존하도록한다.

3번을 선택한 이유는 Checkin 과 Purchase 둘 사이에는 어떠한 연관관계도 없기 때문입니다. (상하 관계 없음) 그래서 컨트롤러 앤드포인트로 요청을 받았을 때 각각의 서비스에 **따로** 메세지를 전달해야하지 않을까 싶어서 3번으로 선택했습니다. 여러분의 의견은 어떠신가요?! 

갑자기 생각난 4번으로는 파사드 패턴 넣어서 파사드서비스가 PurchaseService와 CheckinService 두개를 갖으면서 같이 트랜잭션 묶어줘도 괜찮을거 같다는 생각이..