### PR TITLE
fix#66/ 동적 스케줄링 로직 수정 및 테스트 리팩터링

### DIFF
--- a/src/main/java/com/wootecam/festivals/FestivalsApplication.java
+++ b/src/main/java/com/wootecam/festivals/FestivalsApplication.java
@@ -2,10 +2,8 @@ package com.wootecam.festivals;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class FestivalsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -2,7 +2,6 @@ package com.wootecam.festivals.domain.festival.repository;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalListResponse;
 import com.wootecam.festivals.domain.festival.entity.Festival;
-import com.wootecam.festivals.domain.festival.entity.FestivalProgressStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -40,8 +39,12 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
     );
 
     @Modifying
-    @Query("UPDATE Festival f SET f.festivalProgressStatus = :festivalProgressStatus WHERE f.startTime <= :now AND f.endTime >= :now")
-    void bulkUpdateFestivalStatusFestivals(FestivalProgressStatus festivalProgressStatus, LocalDateTime now);
+    @Query("UPDATE Festival f SET f.festivalProgressStatus = 'COMPLETED' WHERE f.festivalProgressStatus != 'COMPLETED' AND f.endTime <= :now")
+    void bulkUpdateCOMPLETEDFestivals(LocalDateTime now);
+
+    @Modifying
+    @Query("UPDATE Festival f SET f.festivalProgressStatus = 'ONGOING' WHERE f.festivalProgressStatus = 'UPCOMING' AND f.startTime <= :now")
+    void bulkUpdateONGOINGFestivals(LocalDateTime now);
 
     @Query("SELECT f FROM Festival f WHERE f.festivalProgressStatus != 'COMPLETED' AND f.isDeleted = false")
     List<Festival> findFestivalsWithRestartScheduler();

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Slf4j
 @Service
-@Async
 @RequiredArgsConstructor
 public class FestivalSchedulerService {
 
@@ -38,9 +36,9 @@ public class FestivalSchedulerService {
         LocalDateTime now = LocalDateTime.now();
 
         // 완료된 축제는 완료 상태로 벌크성 쿼리로 변경
-        festivalRepository.bulkUpdateCOMPLETEDFestivals(LocalDateTime.now());
+        festivalRepository.bulkUpdateCOMPLETEDFestivals(now);
         // 진행 중인 축제는 진행 중 상태로 벌크성 쿼리로 변경
-        festivalRepository.bulkUpdateONGOINGFestivals(LocalDateTime.now());
+        festivalRepository.bulkUpdateONGOINGFestivals(now);
 
         List<Festival> festivals = festivalRepository.findFestivalsWithRestartScheduler();
 

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
@@ -3,72 +3,58 @@ package com.wootecam.festivals.domain.festival.service;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.entity.FestivalProgressStatus;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
-import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 축제의 시작 시간과 종료 시간을 스케줄링하는 서비스입니다. 서버 재시작 시 모든 축제의 상태를 갱신하고 향후 상태 변경을 스케줄링합니다.
  */
 @Slf4j
 @Service
+@Async
+@RequiredArgsConstructor
 public class FestivalSchedulerService {
 
-    private final ScheduledTaskRegistrar taskRegistrar;
+    private final ThreadPoolTaskScheduler taskScheduler;
     private final FestivalRepository festivalRepository;
-    private final TaskScheduler taskScheduler;
     private final FestivalStatusUpdateService festivalStatusUpdateService;
-
-    public FestivalSchedulerService(FestivalStatusUpdateService festivalStatusUpdateService,
-                                    TaskScheduler taskScheduler,
-                                    FestivalRepository festivalRepository) {
-        this.festivalStatusUpdateService = festivalStatusUpdateService;
-        this.taskScheduler = taskScheduler;
-        this.taskRegistrar = new ScheduledTaskRegistrar();
-        this.taskRegistrar.setTaskScheduler(taskScheduler);
-        this.festivalRepository = festivalRepository;
-    }
 
     /**
      * 서버 재시작 시 모든 축제의 상태를 갱신하고 향후 상태 변경을 스케줄링합니다. 이미 종료된 축제는 완료 상태로 변경하고, 진행 중인 축제는 진행 중 상태로 변경합니다. 아직 시작하지 않은 축제는 시작 및
      * 종료 시간을 스케줄링합니다.
      */
-    @PostConstruct
+    @EventListener(ContextRefreshedEvent.class)
+    @Transactional
     public void scheduleAllFestivals() {
-        List<Festival> festivals = festivalRepository.findFestivalsWithRestartScheduler();
         LocalDateTime now = LocalDateTime.now();
+
+        // 완료된 축제는 완료 상태로 벌크성 쿼리로 변경
+        festivalRepository.bulkUpdateCOMPLETEDFestivals(LocalDateTime.now());
+        // 진행 중인 축제는 진행 중 상태로 벌크성 쿼리로 변경
+        festivalRepository.bulkUpdateONGOINGFestivals(LocalDateTime.now());
+
+        List<Festival> festivals = festivalRepository.findFestivalsWithRestartScheduler();
 
         log.debug("축제 스케줄링 시작. 총 {} 개의 축제가 대상입니다.", festivals.size());
 
         for (Festival festival : festivals) {
-            if (festival.getEndTime().isBefore(now)) {
-                updateCompletedFestival(festival);
-            } else if (festival.getStartTime().isBefore(now) && festival.getEndTime().isAfter(now)) {
-                // 축제가 진행 중인 경우
-                updateOngoingFestival(festival);
-            } else {
-                // 축제가 아직 시작되지 않은 경우
+            if (festival.getStartTime().isAfter(now)) {
                 scheduleStatusUpdate(festival);
+            } else if (festival.getStartTime().isBefore(now) && festival.getEndTime().isAfter(now)) {
+                scheduleEndTimeUpdate(festival);
             }
         }
 
         log.debug("축제 스케줄링 완료.");
-    }
-
-    private void updateCompletedFestival(Festival festival) {
-        festivalRepository.bulkUpdateFestivalStatusFestivals(FestivalProgressStatus.COMPLETED, LocalDateTime.now());
-        log.info("축제 ID: {}가 이미 종료되어 완료 상태로 변경되었습니다.", festival.getId());
-    }
-
-    private void updateOngoingFestival(Festival festival) {
-        festivalRepository.bulkUpdateFestivalStatusFestivals(FestivalProgressStatus.ONGOING, LocalDateTime.now());
-        scheduleEndTimeUpdate(festival);
-        log.info("축제 ID: {}가 진행 중 상태로 변경되었으며, 종료 시간이 스케줄링되었습니다.", festival.getId());
     }
 
     /**
@@ -91,25 +77,33 @@ public class FestivalSchedulerService {
      * @param festival
      */
     private void scheduleStartTimeUpdate(Festival festival) {
-        String cronExpression = createCronExpression(festival.getStartTime());
-        scheduleStatusChange(festival, FestivalProgressStatus.ONGOING, cronExpression, "시작");
+        scheduleStatusChange(festival, FestivalProgressStatus.ONGOING, festival.getStartTime(), "시작");
     }
 
     private void scheduleEndTimeUpdate(Festival festival) {
-        String cronExpression = createCronExpression(festival.getEndTime());
-        scheduleStatusChange(festival, FestivalProgressStatus.COMPLETED, cronExpression, "종료");
+        scheduleStatusChange(festival, FestivalProgressStatus.COMPLETED, festival.getEndTime(), "종료");
     }
 
-    private void scheduleStatusChange(Festival festival, FestivalProgressStatus status, String cronExpression,
+    private void scheduleStatusChange(Festival festival, FestivalProgressStatus status, LocalDateTime scheduledTime,
                                       String eventType) {
-        taskScheduler.schedule(
-                () -> {
-                    festivalStatusUpdateService.updateFestivalStatus(festival.getId(), status);
-                    log.info("축제 ID: {}의 {}가 스케줄링되어 상태가 {}로 변경되었습니다.", festival.getId(), eventType, status);
-                },
-                new CronTrigger(cronExpression)
-        );
-        log.debug("축제 ID: {}의 {} 시간이 {}으로 스케줄링되었습니다.", festival.getId(), eventType, cronExpression);
+        LocalDateTime now = LocalDateTime.now();
+        if (scheduledTime.isBefore(now)) {
+            // 이미 지난 시간의 경우 즉시 실행
+            festivalStatusUpdateService.updateFestivalStatus(festival.getId(), status);
+            log.info("축제 ID: {}의 {} 스케줄링되어 상태가 {}로 즉시 변경되었습니다.", festival.getId(), eventType, status);
+        } else {
+            // 미래의 시간에 대해 스케줄링
+            String cronExpression = createCronExpression(scheduledTime);
+            taskScheduler.schedule(
+                    () -> {
+                        festivalStatusUpdateService.updateFestivalStatus(festival.getId(), status);
+                        log.info("축제 ID: {}의 {} 스케줄링되어 상태가 {}로 변경되었습니다.", festival.getId(), eventType, status);
+                    },
+                    new CronTrigger(cronExpression)
+            );
+            log.debug("축제 ID: {}의 {} 시간이 {}으로 스케줄링되었습니다.", festival.getId(), eventType, cronExpression);
+            log.debug("현재 등록된 스케줄러 개수: {}", taskScheduler.getScheduledThreadPoolExecutor().getQueue().size());
+        }
     }
 
     private String createCronExpression(LocalDateTime dateTime) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,6 @@ spring:
   profiles:
     active: local
     include: secret
-
 ---
 spring:
   config:
@@ -15,7 +14,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
@@ -25,7 +24,11 @@ spring:
     redis:
       host: localhost
       port: 6379
-
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+    com.wootecam.festivals: debug
 ---
 spring:
   config:
@@ -56,33 +59,3 @@ spring:
     level:
       org.hibernate.SQL: debug
       org.hibernate.type: trace
----
-spring:
-  config:
-    activate:
-      on-profile: docker
-  datasource:
-    url: jdbc:mysql://mysql:3306/twodari?useSSL=false&allowPublicKeyRetrieval=true
-    username: root
-    password:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    hibernate:
-      ddl-auto: create
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-  data:
-    redis:
-      host: redis
-      port: 6379
-
-server:
-  port: 8080
-
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
@@ -103,7 +103,6 @@ class FestivalServiceTest extends SpringBootTestConfig {
             // Given
             LocalDateTime now = LocalDateTime.now();
             FestivalCreateRequest requestDto = new FestivalCreateRequest(
-                    admin.getId(),
                     "테스트 축제",
                     "축제 설명",
                     now.plusDays(1),
@@ -111,7 +110,7 @@ class FestivalServiceTest extends SpringBootTestConfig {
             );
 
             // When
-            FestivalIdResponse responseDto = festivalService.createFestival(requestDto);
+            FestivalIdResponse responseDto = festivalService.createFestival(requestDto, admin.getId());
 
             // Then
             assertThat(responseDto).isNotNull();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,4 +27,5 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+    com.wootecam.festivals: debug
 


### PR DESCRIPTION
- 디버그 로깅 설정 추가
  - 디버깅을 위해 application.yml에 로깅 레벨을 추가했습니다. 이를 통해 로깅 정보를 더 상세하게 확인할 수 있습니다.

- @EnableScheduling 제거
  - @EnableScheduling 어노테이션은 주기적으로 실행되는 정적 스케줄링에 사용되기 때문에, 동적 스케줄링에는 필요하지 않아 삭제했어요. 이번 변경에서는 ThreadPoolTaskScheduler를 사용하여 스케줄러를 직접 실행하도록 했습니다.

- ThreadPoolTaskScheduler로 동적 스케줄링 구현
  - 동적으로 태스크를 추가하고 실행하기 위해 ThreadPoolTaskScheduler를 사용했습니다. 이를 통해 큐에 크론 태스크를 저장하고, 실제로 실행되는지 확인하기 위해 SpringBootTest를 사용해 Mock 테스트를 리팩터링했어요 !

- ScheduledTaskRegistrar 사용 검토
  - ScheduledTaskRegistrar를 사용해 동적 태스크를 관리하려 했으나, 이 클래스는 주로 정적 태스크 등록과 실행에 적합하다는 점을 발견했습니다. 
  - ScheduledTaskRegistrar는 다음과 같은 과정을 거칩니다:
    - 태스크가 빈이 초기화되기 전에 addCronTask(), addFixedRateTask() 등을 사용해 등록됩니다.
    - 빈 초기화 시 afterPropertiesSet()이 실행되면서 scheduleTasks()를 호출해 등록된 작업을 실행해요.
  - @EnableScheduling도 ScheduledTaskRegistrar를 자동으로 생성 및 초기화하며, @Scheduled 어노테이션이 붙은 메서드를 자동으로 태스크로 등록해요.
  - 따라서, 동적으로 태스크를 추가하려면 ScheduledTaskRegistrar에 설정된 TaskScheduler를 직접 호출해야 하는데, 이는 ScheduledTaskRegistrar를 사용하는 장점을 살리지 못해요.
  - 복잡성을 줄이기 위해 이번 PR에서는 ThreadPoolTaskScheduler를 사용했습니다. 그러나 정적 로직과 동적 로직이 혼합된 상황에서는 ScheduledTaskRegistrar가 유용할 수 있습니다.

- 크론 태스크 즉시 실행 처리
  - 크론 태스크 등록 시, 시간이 지난 태스크는 스케줄러가 자동으로 실행하지 않기 때문에, 이러한 태스크는 수동으로 즉시 실행되도록 처리했습니다.
  
아래는 실제 동작을 스크린샷으로 찍어봤습니다 ! 참고할 문서는 따로 첨부할께요 ! 시간이 된다면 ScheduledTaskRegistrar 구현체와 @EnableScheduling 내부를 살펴보시는 것도 좋을거 같아요 !
<img width="1000" alt="스크린샷 2024-08-18 오전 12 27 50" src="https://github.com/user-attachments/assets/fcdf6b22-17ab-4024-94ac-f2b26b96c7ad">
<img width="1000" alt="스크린샷 2024-08-18 오전 12 28 16" src="https://github.com/user-attachments/assets/fe93cc64-be74-4a48-b3ff-deda27885ed8">
<img width="1000" alt="스크린샷 2024-08-18 오전 12 29 54" src="https://github.com/user-attachments/assets/bd7a5d12-d928-4025-9243-02ca314577ac">


## 🚨 관련 이슈
closes #66

## 🌈 작업 상황
- application.yml local 및 test 로깅 레벨 설정
- 벌크성 업데이트 쿼리가 논리적으로 맞지 않아서 2개로 분리
- @EnableScheduling 삭제
- FestivalSchedulerService 버그 수정
- FestivalSchedulerServiceTest 테스트 방식을 Mock -> SpringBootTest로 변경
- 페스티벌 생성 시 크론 태스크 추가 테스트 작성

## 📌 기타
https://www.baeldung.com/spring-task-scheduler
https://docs.spring.io/spring-framework/reference/integration/scheduling.html#scheduling-task-executor
https://velog.io/@sunaookamisiroko/spring-scheduler-%EC%9E%91%EB%8F%99-%EC%9B%90%EB%A6%AC
https://assu10.github.io/dev/2023/10/14/springboot-scheduling/
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/config/ScheduledTaskRegistrar.html#addCronTask(java.lang.Runnable,java.lang.String)
