### PR TITLE
feat#63/내가 개최한 페스티벌 목록 조회

### DIFF
--- a/src/docs/asciidoc/api/domain/my/my.adoc
+++ b/src/docs/asciidoc/api/domain/my/my.adoc
@@ -1,0 +1,13 @@
+[[My]]
+== My API
+
+=== 내가 주최한 페스티벌 조회 API
+
+==== 성공
+
+include::{snippets}/my-controller-test/find-hosted-festival/http-request.adoc[]
+
+===== HTTP Response
+
+include::{snippets}/my-controller-test/find-hosted-festival/http-response.adoc[]
+include::{snippets}/my-controller-test/find-hosted-festival/response-fields-data.adoc[]

--- a/src/docs/asciidoc/common/organization-role.adoc
+++ b/src/docs/asciidoc/common/organization-role.adoc
@@ -1,7 +1,0 @@
-:doctype: book
-:icons: font
-
-[[organization-role]]
-=== Organization role
-
-include::{snippets}/common-doc-controller-test/enums/custom-response-fields-organizationRole.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,6 +16,9 @@ include::api/domain/auth/auth.adoc[]
 [[Member-API]]
 include::api/domain/member/member.adoc[]
 
+[[My-API]]
+include::api/domain/my/my.adoc[]
+
 [[Festival-API]]
 include::api/domain/festival/Festival.adoc[]
 

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -2,6 +2,7 @@ package com.wootecam.festivals.domain.festival.repository;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalListResponse;
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -33,10 +34,26 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
             ORDER BY f.startTime ASC, f.id ASC
             """)
     List<FestivalListResponse> findUpcomingFestivalsBeforeCursor(@Param("startTime") LocalDateTime startTime,
-                                                                 @Param("id") Long id,
+                                                                 @Param("id") long id,
                                                                  @Param("now") LocalDateTime now,
-                                                                 Pageable pageable
-    );
+                                                                 Pageable pageable);
+
+    @Query(value = """
+            SELECT new com.wootecam.festivals.domain.my.dto.MyFestivalResponse(f.id, f.title, f.startTime)
+            FROM Festival f WHERE f.admin.id = :adminId
+                        AND f.isDeleted = false
+                        ORDER BY f.startTime DESC, f.id DESC""")
+    List<MyFestivalResponse> findFestivalsByAdminOrderStartTimeDesc(Long adminId, Pageable pageable);
+
+    @Query(value = """
+            SELECT new com.wootecam.festivals.domain.my.dto.MyFestivalResponse(f.id, f.title, f.startTime)
+            FROM Festival f WHERE f.admin.id = :adminId
+                        AND (f.startTime < :startTime OR (f.startTime = :startTime AND f.id < :beforeId))
+                        AND f.isDeleted = false
+                        ORDER BY f.startTime DESC, f.id DESC""")
+    List<MyFestivalResponse> findFestivalsByAdminAndCursorOrderStartTimeDesc(Long adminId, LocalDateTime startTime,
+                                                                             Long beforeId,
+                                                                             Pageable pageable);
 
     @Modifying
     @Query("UPDATE Festival f SET f.festivalProgressStatus = 'COMPLETED' WHERE f.festivalProgressStatus != 'COMPLETED' AND f.endTime <= :now")

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -39,14 +39,14 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
                                                                  Pageable pageable);
 
     @Query(value = """
-            SELECT new com.wootecam.festivals.domain.my.dto.MyFestivalResponse(f.id, f.title, f.startTime)
+            SELECT new com.wootecam.festivals.domain.my.dto.MyFestivalResponse(f.id, f.title, f.festivalImg, f.startTime)
             FROM Festival f WHERE f.admin.id = :adminId
                         AND f.isDeleted = false
                         ORDER BY f.startTime DESC, f.id DESC""")
     List<MyFestivalResponse> findFestivalsByAdminOrderStartTimeDesc(Long adminId, Pageable pageable);
 
     @Query(value = """
-            SELECT new com.wootecam.festivals.domain.my.dto.MyFestivalResponse(f.id, f.title, f.startTime)
+            SELECT new com.wootecam.festivals.domain.my.dto.MyFestivalResponse(f.id, f.title, f.festivalImg, f.startTime)
             FROM Festival f WHERE f.admin.id = :adminId
                         AND (f.startTime < :startTime OR (f.startTime = :startTime AND f.id < :beforeId))
                         AND f.isDeleted = false

--- a/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
@@ -2,20 +2,20 @@ package com.wootecam.festivals.domain.my.controller;
 
 
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
+import com.wootecam.festivals.domain.my.dto.MyFestivalRequestParams;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
 import com.wootecam.festivals.domain.my.service.MyService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import com.wootecam.festivals.global.auth.AuthUser;
 import com.wootecam.festivals.global.auth.Authentication;
 import com.wootecam.festivals.global.page.CursorBasedPage;
-import java.time.LocalDateTime;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,14 +39,12 @@ public class MyController {
     @GetMapping("/festivals")
     public ApiResponse<CursorBasedPage<MyFestivalResponse, MyFestivalCursor>> findHostedFestival(
             @AuthUser Authentication authentication,
-            @RequestParam(name = "time", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-            LocalDateTime cursorTime,
-            @RequestParam(name = "id", required = false) Long cursorId) {
-        log.debug("내가 개최한 축제 목록 조회 요청 - cursorTime: {}, cursorId: {}", cursorTime, cursorId);
+            @Valid @ModelAttribute MyFestivalRequestParams params) {
+        log.debug("내가 개최한 축제 목록 조회 요청 - time: {}, id: {}", params.time(), params.id());
         CursorBasedPage<MyFestivalResponse, MyFestivalCursor> myFestivalPage = myService.findHostedFestival(
-                authentication.memberId(),
-                new MyFestivalCursor(cursorTime, cursorId));
+                authentication.memberId(), new MyFestivalCursor(params.time(), params.id()), params.pageSize());
         log.debug("내가 개최한 축제 목록 조회 완료 - 조회된 축제 수: {}", myFestivalPage.getContent().size());
+
         return ApiResponse.of(myFestivalPage);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
@@ -1,0 +1,52 @@
+package com.wootecam.festivals.domain.my.controller;
+
+
+import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
+import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.domain.my.service.MyService;
+import com.wootecam.festivals.global.api.ApiResponse;
+import com.wootecam.festivals.global.auth.AuthUser;
+import com.wootecam.festivals.global.auth.Authentication;
+import com.wootecam.festivals.global.page.CursorBasedPage;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MyController {
+
+    private final MyService myService;
+
+    /**
+     * 사용자가 개최한 축제 목록을 조회합니다.
+     *
+     * @param loginMemberId 조회할 사용자 ID
+     * @param cursorTime    이전 페이지의 마지막 축제의 시간 (yyyy-MM-dd'T'HH:mm 형식)
+     * @param cursorId      이전 페이지의 마지막 축제의 ID
+     * @return 사용자가 개최한 축제 목록
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/festivals")
+    public ApiResponse<CursorBasedPage<MyFestivalResponse, MyFestivalCursor>> findHostedFestival(
+            @AuthUser Authentication authentication,
+            @RequestParam(name = "time", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+            LocalDateTime cursorTime,
+            @RequestParam(name = "id", required = false) Long cursorId) {
+        log.debug("내가 개최한 축제 목록 조회 요청 - cursorTime: {}, cursorId: {}", cursorTime, cursorId);
+        CursorBasedPage<MyFestivalResponse, MyFestivalCursor> myFestivalPage = myService.findHostedFestival(
+                authentication.memberId(),
+                new MyFestivalCursor(cursorTime, cursorId));
+        log.debug("내가 개최한 축제 목록 조회 완료 - 조회된 축제 수: {}", myFestivalPage.getContent().size());
+        return ApiResponse.of(myFestivalPage);
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalCursor.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalCursor.java
@@ -1,6 +1,9 @@
 package com.wootecam.festivals.domain.my.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.wootecam.festivals.global.utils.CustomLocalDateTimeSerializer;
 import java.time.LocalDateTime;
 
-public record MyFestivalCursor(LocalDateTime startTime, Long id) {
+public record MyFestivalCursor(@JsonSerialize(using = CustomLocalDateTimeSerializer.class) LocalDateTime startTime,
+                               Long id) {
 }

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalCursor.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalCursor.java
@@ -1,0 +1,6 @@
+package com.wootecam.festivals.domain.my.dto;
+
+import java.time.LocalDateTime;
+
+public record MyFestivalCursor(LocalDateTime startTime, Long id) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalRequestParams.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalRequestParams.java
@@ -1,0 +1,22 @@
+package com.wootecam.festivals.domain.my.dto;
+
+import com.wootecam.festivals.global.constants.GlobalConstants;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record MyFestivalRequestParams(@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+                                      LocalDateTime time,
+
+                                      Long id,
+
+                                      @Min(GlobalConstants.MIN_PAGE_SIZE)
+                                      @Max(GlobalConstants.MAX_PAGE_SIZE)
+                                      Integer pageSize) {
+    public MyFestivalRequestParams {
+        if (pageSize == null || pageSize < GlobalConstants.MIN_PAGE_SIZE) {
+            pageSize = GlobalConstants.MIN_PAGE_SIZE;
+        }
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalResponse.java
@@ -1,0 +1,6 @@
+package com.wootecam.festivals.domain.my.dto;
+
+import java.time.LocalDateTime;
+
+public record MyFestivalResponse(Long festivalId, String title, LocalDateTime startTime) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalResponse.java
@@ -1,6 +1,9 @@
 package com.wootecam.festivals.domain.my.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.wootecam.festivals.global.utils.CustomLocalDateTimeSerializer;
 import java.time.LocalDateTime;
 
-public record MyFestivalResponse(Long festivalId, String title, LocalDateTime startTime) {
+public record MyFestivalResponse(Long festivalId, String title, String festivalImg,
+                                 @JsonSerialize(using = CustomLocalDateTimeSerializer.class) LocalDateTime startTime) {
 }

--- a/src/main/java/com/wootecam/festivals/domain/my/service/MyService.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/service/MyService.java
@@ -1,0 +1,53 @@
+package com.wootecam.festivals.domain.my.service;
+
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
+import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.global.page.CursorBasedPage;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+/**
+ * 사용자가 개최하거나 참여한 축체 목록을 조회하는 서비스 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class MyService {
+
+    public static final int OWNED_FESTIVAL_PAGE_SIZE = 10;
+
+    private final FestivalRepository festivalRepository;
+
+    /**
+     * 사용자가 개최한 축제 목록을 조회합니다.
+     *
+     * @param loginMemberId 조회할 사용자 ID
+     * @param cursor        이전 페이지의 마지막 축제의 정보
+     * @return 사용자가 개최한 축제 목록
+     */
+    public CursorBasedPage<MyFestivalResponse, MyFestivalCursor> findHostedFestival(Long loginMemberId,
+                                                                                    MyFestivalCursor cursor) {
+        List<MyFestivalResponse> festivalDtos = findMyFestivalNextPage(loginMemberId, cursor);
+        return new CursorBasedPage<>(festivalDtos, createCursor(festivalDtos), OWNED_FESTIVAL_PAGE_SIZE);
+    }
+
+    private List<MyFestivalResponse> findMyFestivalNextPage(Long loginMemberId, MyFestivalCursor cursor) {
+        if (cursor == null || cursor.id() == null || cursor.startTime() == null) {
+            return festivalRepository.findFestivalsByAdminOrderStartTimeDesc(loginMemberId, Pageable.ofSize(
+                    OWNED_FESTIVAL_PAGE_SIZE + 1));
+        }
+        return festivalRepository.findFestivalsByAdminAndCursorOrderStartTimeDesc(loginMemberId, cursor.startTime(),
+                cursor.id(), Pageable.ofSize(OWNED_FESTIVAL_PAGE_SIZE + 1));
+    }
+
+    private MyFestivalCursor createCursor(List<MyFestivalResponse> festivalDtos) {
+        if (festivalDtos.isEmpty()) {
+            return null;
+        }
+        MyFestivalResponse lastFestival = festivalDtos.get(Math.min(festivalDtos.size(), OWNED_FESTIVAL_PAGE_SIZE) - 1);
+
+        return new MyFestivalCursor(lastFestival.startTime(), lastFestival.festivalId());
+    }
+}

--- a/src/main/java/com/wootecam/festivals/global/constants/GlobalConstants.java
+++ b/src/main/java/com/wootecam/festivals/global/constants/GlobalConstants.java
@@ -1,0 +1,10 @@
+package com.wootecam.festivals.global.constants;
+
+public final class GlobalConstants {
+
+    public static final int MAX_PAGE_SIZE = 30;
+    public static final int MIN_PAGE_SIZE = 10;
+
+    private GlobalConstants() {
+    }
+}

--- a/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
+++ b/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
@@ -1,0 +1,35 @@
+package com.wootecam.festivals.global.page;
+
+import java.util.List;
+
+public class CursorBasedPage<T, U> {
+
+    private final List<T> content;
+    private final U cursor;
+    private final boolean hasNext;
+
+    public CursorBasedPage(List<T> content, U cursor, int pageSize) {
+        if (content.size() > pageSize) {
+            this.hasNext = true;
+            this.content = content.subList(0, pageSize);
+        } else {
+            this.content = content;
+            this.hasNext = false;
+            cursor = null;
+        }
+
+        this.cursor = cursor;
+    }
+
+    public List<T> getContent() {
+        return content;
+    }
+
+    public U getCursor() {
+        return cursor;
+    }
+
+    public boolean hasNext() {
+        return hasNext;
+    }
+}

--- a/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
+++ b/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
@@ -11,15 +11,14 @@ public class CursorBasedPage<T, U> {
 
     public CursorBasedPage(List<T> content, U cursor, int pageSize) {
         if (content.size() > pageSize) {
-            this.hasNext = true;
             this.content = content.subList(0, pageSize);
+            this.hasNext = true;
         } else {
             this.content = content;
             this.hasNext = false;
-            cursor = null;
         }
 
-        this.cursor = cursor;
+        this.cursor = (content.size() > pageSize) ? cursor : null;
     }
 
     public List<T> getContent() {

--- a/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
+++ b/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
@@ -1,5 +1,6 @@
 package com.wootecam.festivals.global.page;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public class CursorBasedPage<T, U> {
@@ -29,6 +30,7 @@ public class CursorBasedPage<T, U> {
         return cursor;
     }
 
+    @JsonProperty("hasNext")
     public boolean hasNext() {
         return hasNext;
     }

--- a/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
+++ b/src/main/java/com/wootecam/festivals/global/page/CursorBasedPage.java
@@ -3,6 +3,16 @@ package com.wootecam.festivals.global.page;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
+/**
+ * Cursor 기반 페이징을 위한 클래스
+ * <p>
+ * 페이지 사이즈보다 컨텐츠의 사이즈가 크다면 hasNext를 true로 설정하고 컨텐츠를 페이지 사이즈만큼 잘라서 저장한다.
+ * <p>
+ * hasNext가 false라면 cursor를 null로 설정한다.
+ *
+ * @param <T> content의 타입
+ * @param <U> cursor의 타입
+ */
 public class CursorBasedPage<T, U> {
 
     private final List<T> content;

--- a/src/test/java/com/wootecam/festivals/domain/my/controller/MyControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/controller/MyControllerTest.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.domain.my.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
@@ -15,10 +16,13 @@ import com.wootecam.festivals.docs.utils.RestDocsSupport;
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
 import com.wootecam.festivals.domain.my.service.MyService;
+import com.wootecam.festivals.global.constants.GlobalConstants;
 import com.wootecam.festivals.global.page.CursorBasedPage;
 import com.wootecam.festivals.global.utils.DateTimeUtils;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -42,35 +46,25 @@ class MyControllerTest extends RestDocsSupport {
     @DisplayName("내가 개최한 축제 목록 조회 API")
     void findHostedFestival() throws Exception {
         LocalDateTime now = LocalDateTime.now();
-        List<MyFestivalResponse> festivalResponses = List.of(
-                new MyFestivalResponse(11L, "축제11", "image11", now.plusDays(11)),
-                new MyFestivalResponse(10L, "축제10", "image10", now.plusDays(10)),
-                new MyFestivalResponse(9L, "축제9", "image9", now.plusDays(9)),
-                new MyFestivalResponse(8L, "축제8", "image8", now.plusDays(8)),
-                new MyFestivalResponse(7L, "축제7", "image7", now.plusDays(7)),
-                new MyFestivalResponse(6L, "축제6", "image6", now.plusDays(6)),
-                new MyFestivalResponse(5L, "축제5", "image5", now.plusDays(5)),
-                new MyFestivalResponse(4L, "축제4", "image4", now.plusDays(4)),
-                new MyFestivalResponse(3L, "축제3", "image3", now.plusDays(2)),
-                new MyFestivalResponse(2L, "축제2", "image2", now.plusDays(1)),
-                new MyFestivalResponse(1L, "축제1", "image1", now)
-        );
+        List<MyFestivalResponse> festivalResponses = createFestivalResponses(now, GlobalConstants.MIN_PAGE_SIZE + 1);
         MyFestivalCursor nextCursor = new MyFestivalCursor(now.plusDays(1), 2L);
         CursorBasedPage<MyFestivalResponse, MyFestivalCursor> result = new CursorBasedPage<>(festivalResponses,
-                nextCursor, 10);
+                nextCursor, GlobalConstants.MIN_PAGE_SIZE);
 
-        given(myService.findHostedFestival(any(), any())).willReturn(result);
+        given(myService.findHostedFestival(any(), any(), anyInt())).willReturn(result);
 
         mockMvc.perform(get("/api/v1/member/festivals")
                         .param("time", DateTimeUtils.normalizeDateTime(now.plusDays(11)).toString())
-                        .param("id", "12"))
+                        .param("id", "12")
+                        .param("pageSize", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content").isArray())
                 .andExpect(jsonPath("$.data.content[0].festivalId").value(11))
                 .andDo(restDocs.document(
                         queryParameters(
                                 parameterWithName("time").description("다음 페이지 조회를 위한 시간 커서").optional(),
-                                parameterWithName("id").description("다음 페이지 조회를 위한 ID 커서").optional()
+                                parameterWithName("id").description("다음 페이지 조회를 위한 ID 커서").optional(),
+                                parameterWithName("pageSize").description("다음 페이지 사이즈").optional()
                         ),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),
@@ -87,5 +81,16 @@ class MyControllerTest extends RestDocsSupport {
                                 fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
                         )
                 ));
+    }
+
+    private List<MyFestivalResponse> createFestivalResponses(LocalDateTime now, int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(i -> new MyFestivalResponse(
+                        (long) (count + 1 - i),
+                        "축제" + (count + 1 - i),
+                        "image" + (count + 1 - i),
+                        now.plusDays(count + 1 - i)
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/wootecam/festivals/domain/my/controller/MyControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/controller/MyControllerTest.java
@@ -1,0 +1,91 @@
+package com.wootecam.festivals.domain.my.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wootecam.festivals.docs.utils.RestDocsSupport;
+import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
+import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.domain.my.service.MyService;
+import com.wootecam.festivals.global.page.CursorBasedPage;
+import com.wootecam.festivals.global.utils.DateTimeUtils;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(MyController.class)
+@ActiveProfiles("test")
+class MyControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private MyService myService;
+
+    @Override
+    protected Object initController() {
+        return new MyController(myService);
+    }
+
+    @Test
+    @DisplayName("내가 개최한 축제 목록 조회 API")
+    void findHostedFestival() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        List<MyFestivalResponse> festivalResponses = List.of(
+                new MyFestivalResponse(11L, "축제11", "image11", now.plusDays(11)),
+                new MyFestivalResponse(10L, "축제10", "image10", now.plusDays(10)),
+                new MyFestivalResponse(9L, "축제9", "image9", now.plusDays(9)),
+                new MyFestivalResponse(8L, "축제8", "image8", now.plusDays(8)),
+                new MyFestivalResponse(7L, "축제7", "image7", now.plusDays(7)),
+                new MyFestivalResponse(6L, "축제6", "image6", now.plusDays(6)),
+                new MyFestivalResponse(5L, "축제5", "image5", now.plusDays(5)),
+                new MyFestivalResponse(4L, "축제4", "image4", now.plusDays(4)),
+                new MyFestivalResponse(3L, "축제3", "image3", now.plusDays(2)),
+                new MyFestivalResponse(2L, "축제2", "image2", now.plusDays(1)),
+                new MyFestivalResponse(1L, "축제1", "image1", now)
+        );
+        MyFestivalCursor nextCursor = new MyFestivalCursor(now.plusDays(1), 2L);
+        CursorBasedPage<MyFestivalResponse, MyFestivalCursor> result = new CursorBasedPage<>(festivalResponses,
+                nextCursor, 10);
+
+        given(myService.findHostedFestival(any(), any())).willReturn(result);
+
+        mockMvc.perform(get("/api/v1/member/festivals")
+                        .param("time", DateTimeUtils.normalizeDateTime(now.plusDays(11)).toString())
+                        .param("id", "12"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].festivalId").value(11))
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("time").description("다음 페이지 조회를 위한 시간 커서").optional(),
+                                parameterWithName("id").description("다음 페이지 조회를 위한 ID 커서").optional()
+                        ),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("축제 목록"),
+                                fieldWithPath("content[].festivalId").type(JsonFieldType.NUMBER)
+                                        .description("축제 ID"),
+                                fieldWithPath("content[].title").type(JsonFieldType.STRING).description("축제 제목"),
+                                fieldWithPath("content[].festivalImg").type(JsonFieldType.STRING).description("축제 이미지"),
+                                fieldWithPath("content[].startTime").type(JsonFieldType.STRING).description("축제 시작 시각"),
+                                fieldWithPath("cursor").type(JsonFieldType.OBJECT).description("다음 페이지 커서 정보"),
+                                fieldWithPath("cursor.startTime").type(JsonFieldType.STRING)
+                                        .description("다음 페이지의 시작 시각 커서"),
+                                fieldWithPath("cursor.id").type(JsonFieldType.NUMBER).description("다음 페이지의 ID 커서"),
+                                fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -1,0 +1,167 @@
+package com.wootecam.festivals.domain.my.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.entity.FestivalPublicationStatus;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
+import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.global.page.CursorBasedPage;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import com.wootecam.festivals.utils.TestDBCleaner;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("MyService 통합 테스트")
+class MyServiceTest extends SpringBootTestConfig {
+
+    private final MyService myService;
+    private final FestivalRepository festivalRepository;
+    private final MemberRepository memberRepository;
+
+    private Member admin;
+
+    @Autowired
+    public MyServiceTest(MyService myService, FestivalRepository festivalRepository,
+                         MemberRepository memberRepository) {
+        this.myService = myService;
+        this.festivalRepository = festivalRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        TestDBCleaner.clear(festivalRepository);
+        TestDBCleaner.clear(memberRepository);
+        admin = memberRepository.save(
+                Member.builder()
+                        .name("Test Admin")
+                        .email("Test Detail")
+                        .profileImg("Test profileImg")
+                        .build());
+    }
+
+    @Nested
+    @DisplayName("내가 주최한 축제 목록 요청 시")
+    class Describe_findHostedFestival {
+
+        @Test
+        @DisplayName("커서가 없다면 사용자가 개최한 축제 목록의 첫 페이지를 반환한다.")
+        void it_returns_my_festival_list_first_page() {
+            // Given
+            Long loginMemberId = admin.getId();
+            int count = 15;
+            List<Festival> festivals = createFestivals(count);
+
+            // When
+            CursorBasedPage<MyFestivalResponse, MyFestivalCursor> firstPage = myService.findHostedFestival(
+                    loginMemberId, null);
+
+            // Then
+            assertAll(
+                    () -> assertThat(firstPage.getContent()).hasSize(10),
+                    () -> assertThat(firstPage.getCursor()).isNotNull(),
+                    () -> assertThat(firstPage.hasNext()).isTrue(),
+                    () -> assertThat(firstPage.getContent().get(0).festivalId()).isEqualTo(
+                            festivals.get(count - 1).getId()),
+                    () -> assertThat(firstPage.getContent().get(9).festivalId()).isEqualTo(
+                            festivals.get(count - 10).getId())
+            );
+        }
+
+        @Test
+        @DisplayName("커서가 있다면 사용자가 개최한 축제 목록 중 커서의 다음 페이지를 반환한다.")
+        void it_returns_my_festival_list_next_page() {
+            // Given
+            Long loginMemberId = admin.getId();
+            int count = 25;
+            List<Festival> festivals = createFestivals(count);
+            CursorBasedPage<MyFestivalResponse, MyFestivalCursor> firstPage = myService.findHostedFestival(
+                    loginMemberId, null);
+            MyFestivalCursor cursor = firstPage.getCursor();
+
+            // When
+            CursorBasedPage<MyFestivalResponse, MyFestivalCursor> secondPage = myService.findHostedFestival(
+                    loginMemberId, cursor);
+
+            // Then
+            assertAll(
+                    () -> assertThat(secondPage.getContent()).hasSize(10),
+                    () -> assertThat(secondPage.getCursor()).isNotNull(),
+                    () -> assertThat(secondPage.hasNext()).isTrue(),
+                    () -> assertThat(secondPage.getContent().get(0).festivalId()).isEqualTo(
+                            festivals.get(count - 11).getId()),
+                    () -> assertThat(secondPage.getContent().get(9).festivalId()).isEqualTo(
+                            festivals.get(count - 20).getId())
+            );
+        }
+
+        @Test
+        @DisplayName("개최한 축제가 없다면 빈 리스트와 null 커서를 반환한다.")
+        void it_returns_empty_list_and_null_cursor_for_empty_result() {
+            // Given
+            Long loginMemberId = admin.getId();
+
+            // When
+            CursorBasedPage<MyFestivalResponse, MyFestivalCursor> response = myService.findHostedFestival(loginMemberId,
+                    null);
+
+            // Then
+            assertAll(
+                    () -> assertThat(response.getContent()).isEmpty(),
+                    () -> assertThat(response.getCursor()).isNull(),
+                    () -> assertThat(response.hasNext()).isFalse()
+            );
+        }
+
+        @Test
+        @DisplayName("페이지 크기가 전체 결과보다 크다면 모든 결과를 반환하고 다음 페이지가 없음을 표시한다.")
+        void it_returns_all_results_when_page_size_is_larger() {
+            // Given
+            Long loginMemberId = admin.getId();
+            int count = 5;
+            List<Festival> festivals = createFestivals(count);
+
+            // When
+            CursorBasedPage<MyFestivalResponse, MyFestivalCursor> response = myService.findHostedFestival(loginMemberId,
+                    null);
+
+            // Then
+            assertAll(
+                    () -> assertThat(response.getContent()).hasSize(count),
+                    () -> assertThat(response.getCursor()).isNull(),
+                    () -> assertThat(response.hasNext()).isFalse(),
+                    () -> assertThat(response.getContent().get(0).festivalId()).isEqualTo(
+                            festivals.get(count - 1).getId()),
+                    () -> assertThat(response.getContent().get(4).festivalId()).isEqualTo(
+                            festivals.get(count - 5).getId())
+            );
+        }
+
+        private List<Festival> createFestivals(int count) {
+            LocalDateTime now = LocalDateTime.now();
+            return IntStream.range(1, count + 1)
+                    .mapToObj(i -> Festival.builder()
+                            .admin(admin)
+                            .title("페스티벌 " + i)
+                            .description("페스티벌 설명 " + i)
+                            .startTime(now.plusDays(i + 1))
+                            .endTime(now.plusDays(i + 8))
+                            .festivalPublicationStatus(FestivalPublicationStatus.PUBLISHED)
+                            .build()
+                    )
+                    .map(festivalRepository::save)
+                    .toList();
+        }
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -10,6 +10,7 @@ import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.global.constants.GlobalConstants;
 import com.wootecam.festivals.global.page.CursorBasedPage;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
@@ -64,7 +65,7 @@ class MyServiceTest extends SpringBootTestConfig {
 
             // When
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> firstPage = myService.findHostedFestival(
-                    loginMemberId, null);
+                    loginMemberId, null, GlobalConstants.MIN_PAGE_SIZE);
 
             // Then
             assertAll(
@@ -86,12 +87,12 @@ class MyServiceTest extends SpringBootTestConfig {
             int count = 25;
             List<Festival> festivals = createFestivals(count);
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> firstPage = myService.findHostedFestival(
-                    loginMemberId, null);
+                    loginMemberId, null, GlobalConstants.MIN_PAGE_SIZE);
             MyFestivalCursor cursor = firstPage.getCursor();
 
             // When
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> secondPage = myService.findHostedFestival(
-                    loginMemberId, cursor);
+                    loginMemberId, cursor, GlobalConstants.MIN_PAGE_SIZE);
 
             // Then
             assertAll(
@@ -113,7 +114,7 @@ class MyServiceTest extends SpringBootTestConfig {
 
             // When
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> response = myService.findHostedFestival(loginMemberId,
-                    null);
+                    null, GlobalConstants.MIN_PAGE_SIZE);
 
             // Then
             assertAll(
@@ -133,7 +134,7 @@ class MyServiceTest extends SpringBootTestConfig {
 
             // When
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> response = myService.findHostedFestival(loginMemberId,
-                    null);
+                    null, GlobalConstants.MIN_PAGE_SIZE);
 
             // Then
             assertAll(

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -12,7 +12,6 @@ import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
 import com.wootecam.festivals.global.page.CursorBasedPage;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
-import com.wootecam.festivals.utils.TestDBCleaner;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -41,8 +40,8 @@ class MyServiceTest extends SpringBootTestConfig {
 
     @BeforeEach
     void setUp() {
-        TestDBCleaner.clear(festivalRepository);
-        TestDBCleaner.clear(memberRepository);
+        clear();
+
         admin = memberRepository.save(
                 Member.builder()
                         .name("Test Admin")


### PR DESCRIPTION
## 📄 작업 설명

나의 페이지애서 내가 개최한 페스티벌 목록을 확인할 수 있는 기능을 구현했어요.
- Dto Projection을 이용해 DTO 컨버팅 로직을 따로 넣지 않았어요.

## 🚨 관련 이슈
closes #63 


## 🌈 작업 상황

- MyController#findHostedFestivals API 구현
- MyService#findHostedFestivals 로직 구현
- FestivalRepository에서 내가 개최한 페스티벌을 커서 기반으로 가져오는 쿼리 구현
- API 문서화
- CursorBasedPage 정의


## 📌 기타
Cursor 기반 페이지네이션을 많이 사용할 것 같아 공통으로 사용할 수 있는 CursorBasedPage를 정의했어요. 기존의 KeySetPageResponse와 역할이 비슷해보여 둘을 비교하여 하나를 삭제하고 공통적으로 사용하면 좋을 것 같아요!
