### PR TITLE
fix#73/TicketValidator 티켓 판매 시간 검증 변경

### DIFF
--- a/src/main/java/com/wootecam/festivals/domain/ticket/utils/TicketValidConstant.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/utils/TicketValidConstant.java
@@ -26,7 +26,7 @@ public final class TicketValidConstant {
 
     public static final String TICKET_TIME_VALID_MESSAGE = "티켓 판매 시작 시간은 판매 종료 시간, 환불 종료 시간보다 빨라야 합니다.";
 
-    public static final String TICKET_START_TIME_VALID_MESSAGE = "티켓 판매 시작 시간은 현재 시간 이후이여야 합니다.";
+    public static final String TICKET_START_TIME_VALID_MESSAGE = "티켓 판매 시작 시간은 이벤트 시작 시간 이전이여야 합니다.";
 
     public static final String TICKET_END_TIME_VALID_MESSAGE = "티켓 판매 종료 시간은 현재 시간 이후 이벤트 종료 시간 이전이여야 합니다.";
 

--- a/src/main/java/com/wootecam/festivals/domain/ticket/utils/TicketValidator.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/utils/TicketValidator.java
@@ -100,15 +100,17 @@ public class TicketValidator {
             throw new IllegalArgumentException(TICKET_TIME_VALID_MESSAGE);
         }
 
-        if (festival.getStartTime().isAfter(startSaleTime)) {
+        if (startSaleTime.isAfter(festival.getStartTime())) {
             throw new IllegalArgumentException(TICKET_START_TIME_VALID_MESSAGE);
         }
 
-        if (LocalDateTime.now().isAfter(endSaleTime) || festival.getEndTime().isBefore(endSaleTime)) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isAfter(endSaleTime) || festival.getEndTime().isBefore(endSaleTime)) {
             throw new IllegalArgumentException(TICKET_END_TIME_VALID_MESSAGE);
         }
 
-        if (LocalDateTime.now().isAfter(refundEndTime)) {
+        if (now.isAfter(refundEndTime)) {
             throw new IllegalArgumentException(TICKET_REFUND_TIME_VALID_MESSAGE);
         }
     }

--- a/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/checkin/service/CheckinServiceTest.java
@@ -61,12 +61,13 @@ class CheckinServiceTest extends SpringBootTestConfig {
                 .build()
         );
 
+        LocalDateTime now = LocalDateTime.now();
         festival = festivalRepository.save(Festival.builder()
                 .admin(member)
                 .title("페스티벌 이름")
                 .description("페스티벌 설명")
-                .startTime(LocalDateTime.now())
-                .endTime(LocalDateTime.now().plusDays(7))
+                .startTime(now)
+                .endTime(now.plusDays(7))
                 .build());
 
         ticket = ticketRepository.save(Ticket.builder()
@@ -74,9 +75,9 @@ class CheckinServiceTest extends SpringBootTestConfig {
                 .detail("Test Ticket Detail")
                 .price(10000L)
                 .quantity(100)
-                .startSaleTime(LocalDateTime.now())
-                .endSaleTime(LocalDateTime.now().plusDays(2))
-                .refundEndTime(LocalDateTime.now().plusDays(2))
+                .startSaleTime(now.minusMinutes(1))
+                .endSaleTime(now.plusDays(2))
+                .refundEndTime(now.plusDays(2))
                 .festival(festival)
                 .build());
     }

--- a/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
@@ -63,7 +63,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
 
         Member admin = memberRepository.save(createMember("admin", "admin@test.com"));
         festival = festivalRepository.save(createFestival(admin, "Test Festival", "Test Festival Detail",
-                ticketSaleStartTime, ticketSaleStartTime.plusDays(4)));
+                ticketSaleStartTime.plusDays(1), ticketSaleStartTime.plusDays(4)));
     }
 
     @Nested

--- a/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketStockTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketStockTest.java
@@ -16,15 +16,15 @@ public class TicketStockTest {
     @DisplayName("decreaseStock는")
     class Describe_decreaseStock {
 
-        Festival festival = FestivalStub.createFestivalWithTime(LocalDateTime.now(), LocalDateTime.now().plusDays(7));
         LocalDateTime now = LocalDateTime.now();
+        Festival festival = FestivalStub.createFestivalWithTime(now, LocalDateTime.now().plusDays(7));
         Ticket ticket = Ticket.builder()
                 .festival(festival)
                 .name("티켓 이름")
                 .detail("티켓 상세")
                 .price(10000L)
                 .quantity(100)
-                .startSaleTime(now)
+                .startSaleTime(now.minusMinutes(1))
                 .endSaleTime(now.plusDays(1))
                 .refundEndTime(now.plusDays(1))
                 .build();

--- a/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketTest.java
@@ -20,8 +20,8 @@ class TicketTest {
     @Test
     @DisplayName("티켓 생성에 성공한다.")
     void createTicket() {
-        Festival festival = FestivalStub.createFestivalWithTime(LocalDateTime.now(), LocalDateTime.now().plusDays(7));
         LocalDateTime now = LocalDateTime.now();
+        Festival festival = FestivalStub.createFestivalWithTime(now, LocalDateTime.now().plusDays(7));
         Ticket ticket = Ticket.builder()
                 .festival(festival)
                 .name("티켓 이름")
@@ -48,9 +48,9 @@ class TicketTest {
     @Nested
     @DisplayName("티켓이 생성되었다면")
     class Describe_createTicketStock {
-        Festival festival = FestivalStub.createFestivalWithTime(LocalDateTime.now(),
-                LocalDateTime.now().plusDays(7));
         LocalDateTime now = LocalDateTime.now();
+        Festival festival = FestivalStub.createFestivalWithTime(now,
+                LocalDateTime.now().plusDays(7));
         Ticket ticket = Ticket.builder()
                 .festival(festival)
                 .name("티켓 이름")

--- a/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
@@ -75,7 +75,7 @@ class TicketServiceTest extends SpringBootTestConfig {
             Festival saveFestival = festivalRepository.save(festival);
 
             TicketCreateRequest ticketCreateRequest = new TicketCreateRequest("티켓 이름", "티켓 설명", 10000L, 100,
-                    now.plusDays(1), now.plusDays(6), now.plusDays(10));
+                    now.minusMinutes(1), now.plusDays(6), now.plusDays(10));
 
             // When
             TicketIdResponse ticketIdResponse = ticketService.createTicket(saveFestival.getId(), ticketCreateRequest);
@@ -138,7 +138,7 @@ class TicketServiceTest extends SpringBootTestConfig {
                         .detail("티켓 설명" + i)
                         .price(10000L)
                         .quantity(100)
-                        .startSaleTime(now.plusDays(1))
+                        .startSaleTime(now.minusMinutes(1))
                         .endSaleTime(now.plusDays(6))
                         .refundEndTime(now.plusDays(10))
                         .build();

--- a/src/test/java/com/wootecam/festivals/domain/ticket/utils/TicketValidatorTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/utils/TicketValidatorTest.java
@@ -11,6 +11,7 @@ import static com.wootecam.festivals.domain.ticket.utils.TicketValidConstant.TIC
 import static com.wootecam.festivals.domain.ticket.utils.TicketValidConstant.TICKET_REFUND_TIME_VALID_MESSAGE;
 import static com.wootecam.festivals.domain.ticket.utils.TicketValidConstant.TICKET_START_TIME_EMPTY_VALID_MESSAGE;
 import static com.wootecam.festivals.domain.ticket.utils.TicketValidConstant.TICKET_START_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.utils.TicketValidConstant.TICKET_TIME_VALID_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -30,40 +31,60 @@ class TicketValidatorTest {
         LocalDateTime now = LocalDateTime.now();
         Festival festival = FestivalStub.createFestivalWithTime(now.plusMinutes(5), LocalDateTime.now().plusDays(7));
         return Stream.of(
+                // 페스티벌이 null 이면 예외
                 Arguments.of(null, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().minusMinutes(1),
                         festival.getEndTime(), festival.getEndTime().minusMinutes(1),
                         TICKET_FESTIVAL_VALID_MESSAGE),
+                // 티켓 이름이 null 이면 예외
                 Arguments.of(festival, null, "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_NAME_VALID_MESSAGE),
+                // 티켓 이름이 빈 문자열이면 예외
                 Arguments.of(festival, "", "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_NAME_VALID_MESSAGE),
+                // 티켓 이름이 100자 초과이면 예외
                 Arguments.of(festival, "a".repeat(101), "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_NAME_VALID_MESSAGE),
+                // 티켓 상세가 1000자 초과이면 예외
                 Arguments.of(festival, "티켓 이름", "a".repeat(1001), 10000L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_DETAIL_VALID_MESSAGE),
+                // 티켓 가격이 null 이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", null, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_PRICE_VALID_MESSAGE),
+                // 티켓 가격이 음수이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", -1L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_PRICE_VALID_MESSAGE),
+                // 티켓 가격이 100억 초과이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000000000L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_PRICE_VALID_MESSAGE),
+                // 티켓 전체 수량이 0 이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 0, now, now.plusDays(1), now.plusDays(1),
                         TICKET_QUANTITY_VALID_MESSAGE),
+                // 티켓 전체 수량이 10만개 초과이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100001, now, now.plusDays(1), now.plusDays(1),
                         TICKET_QUANTITY_VALID_MESSAGE),
+                // 티켓 판매 종료 시간이  티켓 판매 시작 시간보다 빠르면 예외
+                Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().minusMinutes(1),
+                        festival.getStartTime().minusMinutes(2), festival.getEndTime().plusMinutes(2),
+                        TICKET_TIME_VALID_MESSAGE),
+                // 티켓 판매 시작 시간이 null 이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, null, now.plusDays(1), now.plusDays(1),
                         TICKET_START_TIME_EMPTY_VALID_MESSAGE),
+                // 티켓 판매 시작 시간이 페스티벌 시작 시간보다 늦으면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().plusMinutes(1),
                         now.plusDays(1),
                         now.plusDays(1),
                         TICKET_START_TIME_VALID_MESSAGE),
+                // 티켓 판매 종료 시간이 null 이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, now, null, now.plusDays(1),
                         TICKET_END_TIME_EMPTY_VALID_MESSAGE),
+                // 티켓 판매 종료 시간이 페스티벌 종료 시간보다 늦으면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().minusMinutes(1),
                         festival.getEndTime().plusMinutes(1), festival.getEndTime().plusMinutes(2),
                         TICKET_END_TIME_VALID_MESSAGE),
+                // 티켓 환불 종료 시간이 null 이면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(1), null,
                         TICKET_REFUND_TIME_EMPTY_VALID_MESSAGE),
+                // 티켓 환불 종료 시간이 현재 시간보다 빠르면 예외
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(1), now.minusDays(1),
                         TICKET_REFUND_TIME_VALID_MESSAGE)
         );

--- a/src/test/java/com/wootecam/festivals/domain/ticket/utils/TicketValidatorTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/ticket/utils/TicketValidatorTest.java
@@ -27,10 +27,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 class TicketValidatorTest {
 
     private static Stream<Arguments> invalidTicket() {
-        Festival festival = FestivalStub.createFestivalWithTime(LocalDateTime.now(), LocalDateTime.now().plusDays(7));
         LocalDateTime now = LocalDateTime.now();
+        Festival festival = FestivalStub.createFestivalWithTime(now.plusMinutes(5), LocalDateTime.now().plusDays(7));
         return Stream.of(
-                Arguments.of(null, "티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
+                Arguments.of(null, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().minusMinutes(1),
+                        festival.getEndTime(), festival.getEndTime().minusMinutes(1),
                         TICKET_FESTIVAL_VALID_MESSAGE),
                 Arguments.of(festival, null, "티켓 상세", 10000L, 100, now, now.plusDays(1), now.plusDays(1),
                         TICKET_NAME_VALID_MESSAGE),
@@ -52,13 +53,14 @@ class TicketValidatorTest {
                         TICKET_QUANTITY_VALID_MESSAGE),
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, null, now.plusDays(1), now.plusDays(1),
                         TICKET_START_TIME_EMPTY_VALID_MESSAGE),
-                Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, now.minusDays(1), now.plusDays(1),
+                Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().plusMinutes(1),
+                        now.plusDays(1),
                         now.plusDays(1),
                         TICKET_START_TIME_VALID_MESSAGE),
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, now, null, now.plusDays(1),
                         TICKET_END_TIME_EMPTY_VALID_MESSAGE),
-                Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, festival.getEndTime().plusDays(1),
-                        festival.getEndTime().plusDays(2), festival.getEndTime().plusDays(3),
+                Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, festival.getStartTime().minusMinutes(1),
+                        festival.getEndTime().plusMinutes(1), festival.getEndTime().plusMinutes(2),
                         TICKET_END_TIME_VALID_MESSAGE),
                 Arguments.of(festival, "티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(1), null,
                         TICKET_REFUND_TIME_EMPTY_VALID_MESSAGE),
@@ -86,11 +88,12 @@ class TicketValidatorTest {
     @Test
     @DisplayName("티켓이 유효한 경우 예외를 던지지 않는다.")
     void validShouldSuccess() {
-        Festival festival = FestivalStub.createValidFestival(1L);
         LocalDateTime now = LocalDateTime.now();
+        Festival festival = FestivalStub.createValidFestival(1L);
 
         assertThatCode(
-                () -> TicketValidator.validTicket(festival, "티켓 이름", "티켓 상세", 10000L, 100, now, now.plusDays(2),
+                () -> TicketValidator.validTicket(festival, "티켓 이름", "티켓 상세", 10000L, 100,
+                        festival.getStartTime().minusMinutes(1), now.plusDays(2),
                         now.plusDays(1)))
                 .doesNotThrowAnyException();
     }


### PR DESCRIPTION
## 📄 작업 설명
 티켓 판매 시간 검증을 변경했어요.
기존 현재 시간보다 앞서야 한다 -> 티켓 판매 시간이 페스티벌 시작 시간 전이여야 한다. 로 바꾸었습니다.
이벤트 시작 전에 티켓 판매를 열어야 한다고 생각해 이렇게 바꾸었고, 따라서 되지 않는 테스트 로직들을 전부 수정했습니다 !
## 🚨 관련 이슈
closes #73 

## 🌈 작업 상황
- 티켓 판매 시간 검증 로직 수정
- 실패 테스트 수정

## 📌 기타
