### PR TITLE
feat#61/페스티벌 참여자 목록 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/api/domain/festival/FestivalParticipant.adoc
+++ b/src/docs/asciidoc/api/domain/festival/FestivalParticipant.adoc
@@ -1,0 +1,28 @@
+[[Festival]]
+== Festival API
+
+=== 축제 참가자 조회 페이지네이션 API
+
+==== HTTP Request
+
+include::{snippets}/festival-participant-controller-test/get-participants/http-request.adoc[]
+include::{snippets}/festival-participant-controller-test/get-participants/query-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/festival-participant-controller-test/get-participants/http-response.adoc[]
+include::{snippets}/festival-participant-controller-test/get-participants/response-fields-data.adoc[]
+
+==== 사용 예시
+
+===== 첫 페이지 요청
+
+----
+GET /api/v1/festivals/1/participants?pageSize=10
+----
+
+===== 다음 페이지 요청
+
+----
+GET /api/v1/festivals/1/participants?pageSize=10&page=1
+----

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantController.java
@@ -7,6 +7,7 @@ import com.wootecam.festivals.domain.festival.service.FestivalParticipantService
 import com.wootecam.festivals.global.api.ApiResponse;
 import com.wootecam.festivals.global.auth.AuthUser;
 import com.wootecam.festivals.global.auth.Authentication;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -42,7 +43,7 @@ public class FestivalParticipantController {
 
         ParticipantsPaginationResponse response =
                 festivalParticipantService.getParticipantListWithPagination(requestMemberId, festivalId, pageable);
-        log.debug("페스티벌 참가자 리스트 페이지네이션 응답: {}", response);
+        log.debug("페스티벌 참가자 리스트 페이지네이션 응답: 시간={}", LocalDateTime.now());
 
         return ApiResponse.of(response);
     }

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantController.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.domain.festival.controller;
 
 
+import com.wootecam.festivals.domain.festival.dto.PagingRequest;
 import com.wootecam.festivals.domain.festival.dto.ParticipantsPaginationResponse;
 import com.wootecam.festivals.domain.festival.service.FestivalParticipantService;
 import com.wootecam.festivals.global.api.ApiResponse;
@@ -12,9 +13,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,10 +34,9 @@ public class FestivalParticipantController {
     @GetMapping
     public ApiResponse<ParticipantsPaginationResponse> getParticipants(@AuthUser Authentication authentication,
                                                                        @PathVariable Long festivalId,
-                                                                       @RequestParam int page,
-                                                                       @RequestParam int size) {
+                                                                       @ModelAttribute PagingRequest pagingRequest) {
         Long requestMemberId = authentication.memberId();
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         log.debug("페스티벌 참가자 리스트 페이지네이션: requestMemberId={}, festivalId={}, pageable={}", requestMemberId, festivalId,
                 pageable);
 

--- a/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantController.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantController.java
@@ -1,0 +1,49 @@
+package com.wootecam.festivals.domain.festival.controller;
+
+
+import com.wootecam.festivals.domain.festival.dto.ParticipantsPaginationResponse;
+import com.wootecam.festivals.domain.festival.service.FestivalParticipantService;
+import com.wootecam.festivals.global.api.ApiResponse;
+import com.wootecam.festivals.global.auth.AuthUser;
+import com.wootecam.festivals.global.auth.Authentication;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+ * 축제 참가자 관련 API를 처리하는 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/festivals/{festivalId}/participants")
+@RequiredArgsConstructor
+public class FestivalParticipantController {
+
+    private final FestivalParticipantService festivalParticipantService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    public ApiResponse<ParticipantsPaginationResponse> getParticipants(@AuthUser Authentication authentication,
+                                                                       @PathVariable Long festivalId,
+                                                                       @RequestParam int page,
+                                                                       @RequestParam int size) {
+        Long requestMemberId = authentication.memberId();
+        Pageable pageable = PageRequest.of(page, size);
+        log.debug("페스티벌 참가자 리스트 페이지네이션: requestMemberId={}, festivalId={}, pageable={}", requestMemberId, festivalId,
+                pageable);
+
+        ParticipantsPaginationResponse response =
+                festivalParticipantService.getParticipantListWithPagination(requestMemberId, festivalId, pageable);
+        log.debug("페스티벌 참가자 리스트 페이지네이션 응답: {}", response);
+
+        return ApiResponse.of(response);
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/PagingRequest.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/PagingRequest.java
@@ -1,0 +1,20 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import com.wootecam.festivals.global.constants.GlobalConstants;
+
+public record PagingRequest(Integer page, Integer size) {
+    public PagingRequest {
+        // page가 null이거나 0보다 작은 경우 첫번째 페이지로 초기화
+        if (page == null || page < 0) {
+            page = 0;
+        }
+
+        if (size == null || size < GlobalConstants.MIN_PAGE_SIZE) {
+            size = GlobalConstants.MIN_PAGE_SIZE;
+        }
+
+        if (size > GlobalConstants.MAX_PAGE_SIZE) {
+            size = GlobalConstants.MAX_PAGE_SIZE;
+        }
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/ParticipantResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/ParticipantResponse.java
@@ -1,0 +1,12 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.wootecam.festivals.global.utils.CustomLocalDateTimeSerializer;
+import java.time.LocalDateTime;
+
+public record ParticipantResponse(Long participantId, String participantName, String participantEmail,
+                                  Long ticketId, String ticketName,
+                                  Long purchaseId,
+                                  @JsonSerialize(using = CustomLocalDateTimeSerializer.class) LocalDateTime purchaseTime,
+                                  Long checkinId, boolean isCheckin) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/dto/ParticipantsPaginationResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/dto/ParticipantsPaginationResponse.java
@@ -1,0 +1,22 @@
+package com.wootecam.festivals.domain.festival.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record ParticipantsPaginationResponse(List<ParticipantResponse> participants,
+                                             int currentPage,
+                                             int itemsPerPage,
+                                             long totalItems,
+                                             int totalPages,
+                                             boolean hasNext,
+                                             boolean hasPrevious) {
+    public static ParticipantsPaginationResponse from(Page<ParticipantResponse> participantsPagination) {
+        return new ParticipantsPaginationResponse(participantsPagination.getContent(),
+                participantsPagination.getNumber(),
+                participantsPagination.getSize(),
+                participantsPagination.getTotalElements(),
+                participantsPagination.getTotalPages(),
+                participantsPagination.hasNext(),
+                participantsPagination.hasPrevious());
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/exception/FestivalErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/exception/FestivalErrorCode.java
@@ -11,6 +11,7 @@ public enum FestivalErrorCode implements ErrorCode, EnumType {
     // 클라이언트 오류
     INVALID_FESTIVAL_DATA(HttpStatus.BAD_REQUEST, "FS-0001", "Festival 데이터에 문제가 있습니다."),
     FESTIVAL_NOT_FOUND(HttpStatus.BAD_REQUEST, "FS-0002", "Festival이 존재하지 않습니다."),
+    FESTIVAL_NOT_AUTHORIZED(HttpStatus.BAD_REQUEST, "FS-0003", "Festival에 대한 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wootecam/festivals/domain/festival/exception/FestivalErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/exception/FestivalErrorCode.java
@@ -11,7 +11,7 @@ public enum FestivalErrorCode implements ErrorCode, EnumType {
     // 클라이언트 오류
     INVALID_FESTIVAL_DATA(HttpStatus.BAD_REQUEST, "FS-0001", "Festival 데이터에 문제가 있습니다."),
     FESTIVAL_NOT_FOUND(HttpStatus.BAD_REQUEST, "FS-0002", "Festival이 존재하지 않습니다."),
-    FESTIVAL_NOT_AUTHORIZED(HttpStatus.BAD_REQUEST, "FS-0003", "Festival에 대한 권한이 없습니다."),
+    FESTIVAL_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "FS-0003", "Festival에 대한 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -1,11 +1,13 @@
 package com.wootecam.festivals.domain.festival.repository;
 
 import com.wootecam.festivals.domain.festival.dto.FestivalListResponse;
+import com.wootecam.festivals.domain.festival.dto.ParticipantResponse;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -17,6 +19,9 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
     @Query("SELECT f FROM Festival f WHERE f.id = :id AND f.isDeleted = false")
     @Override
     Optional<Festival> findById(Long id);
+
+    @Query("SELECT f FROM Festival f JOIN FETCH f.admin WHERE f.id = :id AND f.isDeleted = false")
+    Optional<Festival> findByIdWithAdminMember(Long id);
 
     @Query("""
             SELECT new com.wootecam.festivals.domain.festival.dto.FestivalListResponse(
@@ -65,4 +70,29 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
     @Query("SELECT f FROM Festival f WHERE f.festivalProgressStatus != 'COMPLETED' AND f.isDeleted = false")
     List<Festival> findFestivalsWithRestartScheduler();
+
+
+    @Query(value = """
+            SELECT DISTINCT new com.wootecam.festivals.domain.festival.dto.ParticipantResponse(
+                p.id, p.name, p.email,
+                t.id, t.name,
+                pu.id, pu.purchaseTime,
+                c.id, c.isChecked
+            )
+            FROM Festival f\s
+            INNER JOIN Ticket t ON t.festival.id = f.id AND t.isDeleted = false
+            INNER JOIN Member p ON p.isDeleted = false
+            INNER JOIN Purchase pu ON pu.ticket.id = t.id AND pu.member.id = p.id
+            INNER JOIN Checkin c ON c.ticket.id = t.id AND c.member.id = p.id
+            WHERE f.id = :festivalId AND f.isDeleted = false\s
+            ORDER BY pu.purchaseTime ASC
+            """,
+            countQuery = """
+                    SELECT COUNT(DISTINCT p.id)
+                    FROM Festival f
+                    INNER JOIN Purchase pu ON pu.ticket.festival.id = f.id
+                    INNER JOIN Member p ON p.id = pu.member.id AND p.isDeleted = false
+                    WHERE f.id = :festivalId AND f.isDeleted = false
+            """)
+    Page<ParticipantResponse> findParticipantsWithPagination(Long festivalId, Pageable pageable);
 }

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -84,7 +84,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
             INNER JOIN Member p ON p.isDeleted = false
             INNER JOIN Purchase pu ON pu.ticket.id = t.id AND pu.member.id = p.id
             INNER JOIN Checkin c ON c.ticket.id = t.id AND c.member.id = p.id
-            WHERE f.id = :festivalId AND f.isDeleted = false\s
+            WHERE f.id = :festivalId AND f.isDeleted = false 
             ORDER BY pu.purchaseTime ASC
             """,
             countQuery = """

--- a/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -79,7 +79,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
                 pu.id, pu.purchaseTime,
                 c.id, c.isChecked
             )
-            FROM Festival f\s
+            FROM Festival f 
             INNER JOIN Ticket t ON t.festival.id = f.id AND t.isDeleted = false
             INNER JOIN Member p ON p.isDeleted = false
             INNER JOIN Purchase pu ON pu.ticket.id = t.id AND pu.member.id = p.id

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantService.java
@@ -1,0 +1,53 @@
+package com.wootecam.festivals.domain.festival.service;
+
+import com.wootecam.festivals.domain.festival.dto.ParticipantResponse;
+import com.wootecam.festivals.domain.festival.dto.ParticipantsPaginationResponse;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FestivalParticipantService {
+
+    private final FestivalRepository festivalRepository;
+
+    public ParticipantsPaginationResponse getParticipantListWithPagination(Long requestMemberId, Long festivalId,
+                                                                           Pageable pageable) {
+        checkFestivalAuth(requestMemberId, festivalId);
+
+        Page<ParticipantResponse> participantsWithPagination = festivalRepository.findParticipantsWithPagination(
+                festivalId, pageable);
+        log.debug("페스티벌 참가자 리스트 페이지네이션 결과: {}", participantsWithPagination);
+        log.debug("페이지 정보: {}", participantsWithPagination.getPageable());
+
+        ParticipantsPaginationResponse response = ParticipantsPaginationResponse.from(participantsWithPagination);
+        log.debug("페스티벌 참가자 리스트 페이지네이션 응답: participantSize={}, response={}", response.participants().size(), response);
+
+        return response;
+    }
+
+    private void checkFestivalAuth(Long requestMemberId, Long festivalId) {
+        Festival festival = festivalRepository.findByIdWithAdminMember(festivalId)
+                .orElseThrow(() -> {
+                    log.error("페스티벌 참가자 리스트 페이지네이션: 페스티벌을 찾을 수 없습니다. festivalId={}", festivalId);
+                    return new ApiException(FestivalErrorCode.FESTIVAL_NOT_FOUND);
+                });
+
+        Long adminId = festival.getAdmin().getId();
+        log.debug("페스티벌 참가자 리스트 페이지네이션: 페스티벌 권한 확인. festivalId={}, adminId={}, requestMemberId={}", festivalId, adminId,
+                requestMemberId);
+        if (!adminId.equals(requestMemberId)) {
+            log.error("페스티벌 참가자 리스트 페이지네이션: 페스티벌에 대한 권한이 없습니다. festivalId={}, adminId={}, requestMemberId={}",
+                    festivalId, adminId, requestMemberId);
+            throw new ApiException(FestivalErrorCode.FESTIVAL_NOT_AUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantService.java
+++ b/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantService.java
@@ -29,7 +29,7 @@ public class FestivalParticipantService {
         log.debug("페이지 정보: {}", participantsWithPagination.getPageable());
 
         ParticipantsPaginationResponse response = ParticipantsPaginationResponse.from(participantsWithPagination);
-        log.debug("페스티벌 참가자 리스트 페이지네이션 응답: participantSize={}, response={}", response.participants().size(), response);
+        log.debug("페스티벌 참가자 리스트 페이지네이션 응답: participantSize={}", response.participants().size());
 
         return response;
     }

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalRequestParams.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalRequestParams.java
@@ -1,18 +1,12 @@
 package com.wootecam.festivals.domain.my.dto;
 
 import com.wootecam.festivals.global.constants.GlobalConstants;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public record MyFestivalRequestParams(@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
                                       LocalDateTime time,
-
                                       Long id,
-
-                                      @Min(GlobalConstants.MIN_PAGE_SIZE)
-                                      @Max(GlobalConstants.MAX_PAGE_SIZE)
                                       Integer pageSize) {
     public MyFestivalRequestParams {
         if (pageSize == null || pageSize < GlobalConstants.MIN_PAGE_SIZE) {

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalRequestParams.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyFestivalRequestParams.java
@@ -12,5 +12,9 @@ public record MyFestivalRequestParams(@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH
         if (pageSize == null || pageSize < GlobalConstants.MIN_PAGE_SIZE) {
             pageSize = GlobalConstants.MIN_PAGE_SIZE;
         }
+
+        if (pageSize > GlobalConstants.MAX_PAGE_SIZE) {
+            pageSize = GlobalConstants.MAX_PAGE_SIZE;
+        }
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
@@ -19,7 +19,7 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
                 t.startSaleTime, t.endSaleTime, t.refundEndTime, t.createdAt, t.updatedAt
             ) 
             FROM Ticket t 
-            LEFT JOIN TicketStock ts ON t.id = ts.ticket.id 
+            INNER JOIN TicketStock ts ON t.id = ts.ticket.id 
             WHERE t.festival.id = :festivalId AND t.isDeleted = false
             """)
     List<TicketResponse> findTicketsByFestivalIdWithRemainStock(Long festivalId);

--- a/src/main/java/com/wootecam/festivals/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wootecam/festivals/global/exception/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler {
         ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INTERNAL_SERVER_ERROR.getCode(),
                 "서비스 장애가 발생했습니다.");
 
-        log.error("{}", errorResponse);
+        log.error("{}", exception);
 
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
         ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
                 errorMessage);
 
-        log.error("{}", errorResponse);
+        log.error("{}", exception);
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
         ApiErrorResponse errorResponse = ApiErrorResponse.of(GlobalErrorCode.INVALID_REQUEST_PARAMETER.getCode(),
                 errorMessage);
 
-        log.error("{}", errorResponse);
+        log.error("{}", exception);
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantControllerTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/controller/FestivalParticipantControllerTest.java
@@ -1,0 +1,112 @@
+package com.wootecam.festivals.domain.festival.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wootecam.festivals.docs.utils.RestDocsSupport;
+import com.wootecam.festivals.domain.festival.dto.ParticipantResponse;
+import com.wootecam.festivals.domain.festival.dto.ParticipantsPaginationResponse;
+import com.wootecam.festivals.domain.festival.service.FestivalParticipantService;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(FestivalParticipantController.class)
+@ActiveProfiles("test")
+class FestivalParticipantControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private FestivalParticipantService festivalParticipantService;
+
+    @Override
+    protected Object initController() {
+        return new FestivalParticipantController(festivalParticipantService);
+    }
+
+    @Test
+    @DisplayName("참가자 목록 페이지네이션 조회 API")
+    void getParticipants() throws Exception {
+        // given
+        List<ParticipantResponse> participantResponses = new ArrayList<>();
+        for (long i = 1; i <= 10; i++) {
+            ParticipantResponse participantResponse = new ParticipantResponse(i, "name" + i, "email" + i,
+                    i, "ticket" + i, i, LocalDateTime.now(), i, false);
+
+            participantResponses.add(participantResponse);
+        }
+
+        given(festivalParticipantService.getParticipantListWithPagination(any(), any(), any()))
+                .willReturn(new ParticipantsPaginationResponse(participantResponses,
+                        10, 10,
+                        1000, 1000 / 10,
+                        true, true));
+
+        // when, then
+        mockMvc.perform(get("/api/v1/festivals/{festivalId}/participants", 1L)
+                        .queryParam("page", "10")
+                        .queryParam("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.participants").isArray())
+                .andExpect(jsonPath("$.data.participants.length()").value(10))
+                .andExpect(jsonPath("$.data.currentPage").value(10))
+                .andExpect(jsonPath("$.data.totalPages").value(100))
+                .andExpect(jsonPath("$.data.totalItems").value(1000))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.hasPrevious").value(true))
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("participants").type(JsonFieldType.ARRAY)
+                                        .description("참가자 목록"),
+                                fieldWithPath("participants[].participantId").type(JsonFieldType.NUMBER)
+                                        .description("참가자 식별자"),
+                                fieldWithPath("participants[].participantName").type(JsonFieldType.STRING)
+                                        .description("참가자 이름"),
+                                fieldWithPath("participants[].participantEmail").type(JsonFieldType.STRING)
+                                        .description("참가자 이메일"),
+                                fieldWithPath("participants[].ticketId").type(JsonFieldType.NUMBER)
+                                        .description("티켓 식별자"),
+                                fieldWithPath("participants[].ticketName").type(JsonFieldType.STRING)
+                                        .description("티켓 이름"),
+                                fieldWithPath("participants[].purchaseId").type(JsonFieldType.NUMBER)
+                                        .description("구매 식별자"),
+                                fieldWithPath("participants[].purchaseTime").type(JsonFieldType.STRING)
+                                        .description("구매 시간"),
+                                fieldWithPath("participants[].checkinId").type(JsonFieldType.NUMBER)
+                                        .description("체크인 식별자"),
+                                fieldWithPath("participants[].isCheckin").type(JsonFieldType.BOOLEAN)
+                                        .description("체크인 여부"),
+                                fieldWithPath("currentPage").type(JsonFieldType.NUMBER)
+                                        .description("현재 페이지"),
+                                fieldWithPath("itemsPerPage").type(JsonFieldType.NUMBER)
+                                        .description("페이지 크기"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER)
+                                        .description("전체 페이지 수"),
+                                fieldWithPath("totalItems").type(JsonFieldType.NUMBER)
+                                        .description("전체 참가자 수"),
+                                fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                                        .description("다음 페이지 존재 여부"),
+                                fieldWithPath("hasPrevious").type(JsonFieldType.BOOLEAN)
+                                        .description("이전 페이지 존재 여부")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/festival/fixture/FestivalParticipantFixture.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/fixture/FestivalParticipantFixture.java
@@ -1,0 +1,99 @@
+package com.wootecam.festivals.domain.festival.fixture;
+
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.purchase.entity.Purchase;
+import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FestivalParticipantFixture {
+
+    private FestivalParticipantFixture() {
+    }
+
+    public static List<Member> createMembers(int count) {
+        List<Member> members = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            Member member = Member.builder()
+                    .name("name" + i)
+                    .email("email" + i)
+                    .profileImg("profileImg" + i)
+                    .build();
+
+            members.add(member);
+        }
+
+        return members;
+    }
+
+    public static Festival createFestival(Member admin) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Festival.builder()
+                .admin(admin)
+                .title("테스트 축제")
+                .description("축제 설명")
+                .startTime(now.plusDays(2))
+                .endTime(now.plusDays(7))
+                .build();
+    }
+
+    public static List<Ticket> createTickets(int count, Festival festival) {
+        List<Ticket> tickets = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            Ticket ticket = Ticket.builder()
+                    .festival(festival)
+                    .name("ticket" + i)
+                    .detail("ticket detail" + i)
+                    .price(i * 1000L)
+                    .quantity(i * 10)
+                    .startSaleTime(festival.getStartTime().minusDays(1))
+                    .endSaleTime(festival.getStartTime().plusDays(3))
+                    .refundEndTime(festival.getEndTime().minusDays(1))
+                    .build();
+
+            tickets.add(ticket);
+        }
+
+        return tickets;
+    }
+
+    public static List<Purchase> createPurchases(List<Member> members, List<Ticket> tickets) {
+        List<Purchase> purchases = new ArrayList<>();
+
+        for (int i = 0; i < members.size(); i++) {
+            int ticketIndex = i % tickets.size();
+            Purchase purchase = Purchase.builder()
+                    .member(members.get(i))
+                    .ticket(tickets.get(ticketIndex))
+                    .purchaseTime(tickets.get(ticketIndex).getStartSaleTime().plusDays(1))
+                    .purchaseStatus(PurchaseStatus.PURCHASED)
+                    .build();
+
+            purchases.add(purchase);
+        }
+
+        return purchases;
+    }
+
+    public static List<Checkin> createCheckins(List<Purchase> purchases) {
+        List<Checkin> checkins = new ArrayList<>();
+
+        for (int i = 0; i < purchases.size(); i++) {
+            Checkin checkin = Checkin.builder()
+                    .member(purchases.get(i).getMember())
+                    .ticket(purchases.get(i).getTicket())
+                    .build();
+
+            checkins.add(checkin);
+        }
+
+        return checkins;
+    }
+}

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantServiceTest.java
@@ -31,12 +31,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.ActiveProfiles;
 
 @Nested
-@DisplayName("FestivalParticipantService 클래스의")
+@DisplayName("FestivalParticipantService 클래스")
 @SpringBootTest
-@ActiveProfiles("local")
 class FestivalParticipantServiceTest extends SpringBootTestConfig {
 
     @Autowired

--- a/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalParticipantServiceTest.java
@@ -1,0 +1,203 @@
+package com.wootecam.festivals.domain.festival.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.wootecam.festivals.domain.checkin.entity.Checkin;
+import com.wootecam.festivals.domain.checkin.repository.CheckinRepository;
+import com.wootecam.festivals.domain.festival.dto.ParticipantsPaginationResponse;
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.exception.FestivalErrorCode;
+import com.wootecam.festivals.domain.festival.fixture.FestivalParticipantFixture;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.domain.purchase.entity.Purchase;
+import com.wootecam.festivals.domain.purchase.repository.PurchaseRepository;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+@Nested
+@DisplayName("FestivalParticipantService 클래스의")
+@SpringBootTest
+@ActiveProfiles("local")
+class FestivalParticipantServiceTest extends SpringBootTestConfig {
+
+    @Autowired
+    private FestivalParticipantService festivalParticipantService;
+
+    @Autowired
+    private FestivalRepository festivalRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private CheckinRepository checkinRepository;
+
+    @Autowired
+    private PurchaseRepository purchaseRepository;
+
+    Festival festival;
+
+    Member admin;
+
+    @BeforeEach
+    void setUp() {
+        clear();
+        List<Member> members = FestivalParticipantFixture.createMembers(100);
+        admin = members.get(0);
+        festival = FestivalParticipantFixture.createFestival(admin);
+        List<Ticket> tickets = FestivalParticipantFixture.createTickets(10, festival);
+        List<Purchase> purchases = FestivalParticipantFixture.createPurchases(members, tickets);
+        List<Checkin> checkins = FestivalParticipantFixture.createCheckins(purchases);
+
+        memberRepository.saveAll(members);
+        festivalRepository.save(festival);
+        ticketRepository.saveAll(tickets);
+        purchaseRepository.saveAll(purchases);
+        checkinRepository.saveAll(checkins);
+    }
+
+    @Nested
+    @DisplayName("getParticipantListWithPagination 메소드는 현재 요청자의 아이디와 페스티벌 아이디와 페이지 정보를 받아")
+    class Describe_getParticipantListWithPagination {
+
+        @Test
+        @DisplayName("페스티벌 참가자 리스트 페이지네이션 결과를 반환한다. - 0번째 페이지")
+        void it_returns_participants_pagination_response_zero_page() {
+            //given
+            Pageable pageable = PageRequest.of(0, 10);
+
+            //when
+            ParticipantsPaginationResponse response = festivalParticipantService.getParticipantListWithPagination(
+                    admin.getId(),
+                    festival.getId(), pageable);
+
+            //then
+            assertAll(() -> assertNotNull(response),
+                    () -> assertThat(response.participants()).hasSize(10),
+                    () -> assertThat(response.totalItems()).isEqualTo(100),
+                    () -> assertThat(response.totalPages()).isEqualTo(10),
+                    () -> assertThat(response.currentPage()).isZero(),
+                    () -> assertTrue(response.hasNext()),
+                    () -> assertFalse(response.hasPrevious())
+            );
+        }
+
+        @Test
+        @DisplayName("페스티벌 참가자 리스트 페이지네이션 결과를 반환한다. - 4번째 페이지")
+        void it_returns_participants_pagination_response_five_page() {
+            //given
+            Pageable pageable = PageRequest.of(4, 10);
+
+            //when
+            ParticipantsPaginationResponse response = festivalParticipantService.getParticipantListWithPagination(
+                    admin.getId(),
+                    festival.getId(), pageable);
+
+            //then
+            assertAll(() -> assertNotNull(response),
+                    () -> assertThat(response.participants()).hasSize(10),
+                    () -> assertThat(response.totalItems()).isEqualTo(100),
+                    () -> assertThat(response.totalPages()).isEqualTo(10),
+                    () -> assertThat(response.currentPage()).isEqualTo(4),
+                    () -> assertTrue(response.hasNext()),
+                    () -> assertTrue(response.hasPrevious())
+            );
+        }
+
+        @Test
+        @DisplayName("페스티벌 참가자 리스트 페이지네이션 결과를 반환한다. - 마지막(9)번째 페이지")
+        void it_returns_participants_pagination_response_last_page() {
+            //given
+            Pageable pageable = PageRequest.of(9, 10);
+
+            //when
+            ParticipantsPaginationResponse response = festivalParticipantService.getParticipantListWithPagination(
+                    admin.getId(),
+                    festival.getId(), pageable);
+
+            //then
+            assertAll(() -> assertNotNull(response),
+                    () -> assertThat(response.participants()).hasSize(10),
+                    () -> assertThat(response.totalItems()).isEqualTo(100),
+                    () -> assertThat(response.totalPages()).isEqualTo(10),
+                    () -> assertThat(response.currentPage()).isEqualTo(9),
+                    () -> assertFalse(response.hasNext()),
+                    () -> assertTrue(response.hasPrevious())
+            );
+        }
+
+        @Test
+        @DisplayName("페스티벌 참가자 리스트 페이지네이션 결과를 반환한다. - 80개씩 요청하다가 마지막 페이지에선 20개만 반환된다.")
+        void it_returns_participants_pagination_response_last_page_with_20_items() {
+            //given
+            Pageable pageable = PageRequest.of(1, 80);
+
+            //when
+            ParticipantsPaginationResponse response = festivalParticipantService.getParticipantListWithPagination(
+                    admin.getId(),
+                    festival.getId(), pageable);
+
+            //then
+            assertAll(() -> assertNotNull(response),
+                    () -> assertThat(response.participants()).hasSize(20),
+                    () -> assertThat(response.totalItems()).isEqualTo(100),
+                    () -> assertThat(response.totalPages()).isEqualTo(2),
+                    () -> assertThat(response.currentPage()).isEqualTo(1),
+                    () -> assertFalse(response.hasNext()),
+                    () -> assertTrue(response.hasPrevious())
+            );
+        }
+
+        @Test
+        @DisplayName("페스티벌이 없으면 예외를 던진다.")
+        void it_throws_exception_when_festival_not_found() {
+            //given
+            Long invalidFestivalId = festival.getId() + 1;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            //when, then
+            assertThatThrownBy(
+                    () -> festivalParticipantService.getParticipantListWithPagination(admin.getId(), invalidFestivalId,
+                            pageable))
+                    .isInstanceOf(ApiException.class)
+                    .hasMessage(FestivalErrorCode.FESTIVAL_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("페스티벌의 어드민이 아닌 멤버가 조회 시 예외를 던진다.")
+        void it_throws_exception_when_not_admin_member() {
+            //given
+            Long invalidAdminId = admin.getId() + 1;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            //when, then
+            assertThatThrownBy(
+                    () -> festivalParticipantService.getParticipantListWithPagination(invalidAdminId, festival.getId(),
+                            pageable))
+                    .isInstanceOf(ApiException.class)
+                    .hasMessage(FestivalErrorCode.FESTIVAL_NOT_AUTHORIZED.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 📄 작업 설명
페스티벌 참여자 목록을 조회하는 로직을 구현했어요 !
DTO Projection으로 가져와 날리고 Pageable을 통한 커서가 아닌 목록 조회를 이용했어요.
그리고 축제의 호스트인 admin만 볼 수 있도록 권한 체크 로직도 추가되었어요.
테스트도 작성되었는데 사실 Repository의 JPA 쿼리는 추후 고도화 작업에서 쿼리적으로 개선이 필요할 수도 있을거 같아요 !
DDL을 슬슬 작성해야 될 시기가 아닌듯 싶습니다.

궁금한 점은 코멘트 남겨주세요 !
## 🚨 관련 이슈
closes #61 

## 🌈 작업 상황
- 페스티벌 참가자 리스트 페이징 쿼리 작성
- 페스티벌 참가자 페이지네이션 기능 구현
- 페스티벌 페이지네이션에 대한 테스트 작성
- 축제 참가자 조회 페이지네이션 API restDocs 작성
- Exception으로 전역 로그 대상 변경

## 📌 기타
