### PR TITLE
feat#75/ 내가 구매한 특정 티켓 상세 조회 API

### DIFF
--- a/src/docs/asciidoc/api/domain/my/my.adoc
+++ b/src/docs/asciidoc/api/domain/my/my.adoc
@@ -11,3 +11,14 @@ include::{snippets}/my-controller-test/find-hosted-festival/http-request.adoc[]
 
 include::{snippets}/my-controller-test/find-hosted-festival/http-response.adoc[]
 include::{snippets}/my-controller-test/find-hosted-festival/response-fields-data.adoc[]
+
+=== 내가 구매한 티켓 상세 조회 API
+
+==== 성공
+
+include::{snippets}/my-controller-test/find-my-purchased-ticket/http-request.adoc[]
+
+===== HTTP Response
+
+include::{snippets}/my-controller-test/find-my-purchased-ticket/http-response.adoc[]
+include::{snippets}/my-controller-test/find-my-purchased-ticket/response-fields-data.adoc[]

--- a/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
@@ -4,6 +4,7 @@ package com.wootecam.festivals.domain.my.controller;
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalRequestParams;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.domain.my.dto.MyPurchasedTicketResponse;
 import com.wootecam.festivals.domain.my.service.MyService;
 import com.wootecam.festivals.global.api.ApiResponse;
 import com.wootecam.festivals.global.auth.AuthUser;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,5 +48,17 @@ public class MyController {
         log.debug("내가 개최한 축제 목록 조회 완료 - 조회된 축제 수: {}", myFestivalPage.getContent().size());
 
         return ApiResponse.of(myFestivalPage);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/tickets/{ticketId}")
+    public ApiResponse<MyPurchasedTicketResponse> findMyPurchasedTicket(
+            @AuthUser Authentication authentication,
+            @PathVariable Long ticketId) {
+        log.debug("내가 구매한 티켓 조회 요청 - ticketId: {}", ticketId);
+        MyPurchasedTicketResponse myPurchasedTicketResponse = myService.findMyPurchasedTicket(authentication.memberId(), ticketId);
+        log.debug("내가 구매한 티켓 조회 완료 - ticketId: {}", ticketId);
+
+        return ApiResponse.of(myPurchasedTicketResponse);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
@@ -50,6 +50,12 @@ public class MyController {
         return ApiResponse.of(myFestivalPage);
     }
 
+    /**
+     * 사용자가 구매한 티켓을 조회합니다.
+     *
+     * @param ticketId 조회할 티켓 ID
+     * @return 사용자가 구매한 티켓, 축제 정보, 구매 정보
+     */
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/tickets/{ticketId}")
     public ApiResponse<MyPurchasedTicketResponse> findMyPurchasedTicket(

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedTicketResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedTicketResponse.java
@@ -1,0 +1,15 @@
+package com.wootecam.festivals.domain.my.dto;
+
+import com.wootecam.festivals.domain.festival.dto.FestivalResponse;
+import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
+import com.wootecam.festivals.domain.ticket.dto.TicketWithoutStockResponse;
+import java.time.LocalDateTime;
+
+public record MyPurchasedTicketResponse(
+        Long purchaseId,
+        LocalDateTime purchaseTime,
+        PurchaseStatus purchaseStatus,
+        TicketWithoutStockResponse ticket,
+        FestivalResponse festival
+) {
+}

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedTicketResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedTicketResponse.java
@@ -1,12 +1,15 @@
 package com.wootecam.festivals.domain.my.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.wootecam.festivals.domain.festival.dto.FestivalResponse;
 import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
 import com.wootecam.festivals.domain.ticket.dto.TicketWithoutStockResponse;
+import com.wootecam.festivals.global.utils.CustomLocalDateTimeSerializer;
 import java.time.LocalDateTime;
 
 public record MyPurchasedTicketResponse(
         Long purchaseId,
+        @JsonSerialize(using = CustomLocalDateTimeSerializer.class)
         LocalDateTime purchaseTime,
         PurchaseStatus purchaseStatus,
         TicketWithoutStockResponse ticket,

--- a/src/main/java/com/wootecam/festivals/domain/my/service/MyService.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/service/MyService.java
@@ -3,6 +3,10 @@ package com.wootecam.festivals.domain.my.service;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.domain.my.dto.MyPurchasedTicketResponse;
+import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
+import com.wootecam.festivals.domain.purchase.repository.PurchaseRepository;
+import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.global.page.CursorBasedPage;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class MyService {
 
     private final FestivalRepository festivalRepository;
+    private final PurchaseRepository purchaseRepository;
 
     /**
      * 사용자가 개최한 축제 목록을 조회합니다.
@@ -31,6 +36,11 @@ public class MyService {
                                                                                     int pageSize) {
         List<MyFestivalResponse> festivalDtos = findMyFestivalNextPage(loginMemberId, cursor, pageSize);
         return new CursorBasedPage<>(festivalDtos, createCursor(festivalDtos, pageSize), pageSize);
+    }
+
+    public MyPurchasedTicketResponse findMyPurchasedTicket(Long loginMemberId, Long ticketId) {
+        return purchaseRepository.findByMemberIdAndTicketId(loginMemberId, ticketId)
+                .orElseThrow(() -> new ApiException(PurchaseErrorCode.PURCHASE_NOT_FOUND));
     }
 
     private List<MyFestivalResponse> findMyFestivalNextPage(Long loginMemberId, MyFestivalCursor cursor, int pageSize) {

--- a/src/main/java/com/wootecam/festivals/domain/purchase/exception/PurchaseErrorCode.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/exception/PurchaseErrorCode.java
@@ -10,6 +10,7 @@ public enum PurchaseErrorCode implements ErrorCode, EnumType {
 
     INVALID_TICKET_PURCHASE_TIME(HttpStatus.NOT_FOUND, "TK-0001", "해당 티켓을 구매할 수 있는 시간이 아닙니다."),
     ALREADY_PURCHASED_TICKET(HttpStatus.BAD_REQUEST, "TK-0002", "이미 구매한 티켓입니다."),
+    PURCHASE_NOT_FOUND(HttpStatus.NOT_FOUND, "TK-0003", "구매 내역을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wootecam/festivals/domain/purchase/repository/PurchaseRepository.java
+++ b/src/main/java/com/wootecam/festivals/domain/purchase/repository/PurchaseRepository.java
@@ -1,11 +1,30 @@
 package com.wootecam.festivals.domain.purchase.repository;
 
 import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.my.dto.MyPurchasedTicketResponse;
 import com.wootecam.festivals.domain.purchase.entity.Purchase;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
     boolean existsByTicketAndMember(Ticket ticket, Member member);
+
+    @Query("""
+            SELECT new com.wootecam.festivals.domain.my.dto.MyPurchasedTicketResponse(
+            p.id, p.purchaseTime, p.purchaseStatus,  
+            new com.wootecam.festivals.domain.ticket.dto.TicketWithoutStockResponse( 
+            t.id, t.name, t.detail, t.price, t.quantity,
+            t.startSaleTime, t.endSaleTime, t.refundEndTime, t.createdAt, t.updatedAt)
+            , new com.wootecam.festivals.domain.festival.dto.FestivalResponse(
+                    f.id, f.admin.id, f.title, f.description, f.festivalImg, f.startTime, f.endTime, f.festivalPublicationStatus, f.festivalProgressStatus
+                ))
+            FROM Purchase p 
+            JOIN p.ticket t ON t.id = p.ticket.id
+            JOIN t.festival f ON f.id = t.festival.id
+            WHERE p.member.id = :memberId AND t.id = :ticketId
+            """)
+    Optional<MyPurchasedTicketResponse> findByMemberIdAndTicketId(Long memberId, Long ticketId); // TicketStock 조인 x
 }

--- a/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketWithoutStockResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketWithoutStockResponse.java
@@ -1,0 +1,11 @@
+package com.wootecam.festivals.domain.ticket.dto;
+
+import java.time.LocalDateTime;
+
+public record TicketWithoutStockResponse(Long id,
+                             String name, String detail,
+                             Long price, int quantity,
+                             LocalDateTime startSaleTime, LocalDateTime endSaleTime,
+                             LocalDateTime refundEndTime,
+                             LocalDateTime createdAt, LocalDateTime updatedAt) {
+}

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -270,7 +270,7 @@ class MyServiceTest extends SpringBootTestConfig {
                             .detail("티켓 설명")
                             .price(10000L)
                             .quantity(100)
-                            .startSaleTime(festival.getStartTime().plusHours(1))
+                            .startSaleTime(festival.getStartTime().minusHours(2))
                             .endSaleTime(festival.getEndTime().minusHours(1))
                             .refundEndTime(festival.getEndTime().minusHours(1))
                             .build()

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -201,15 +201,6 @@ class MyServiceTest extends SpringBootTestConfig {
             // When
             purchase = createPurchase(ticket);
 
-            System.out.println("구매");
-            List<Purchase> all = purchaseRepository.findAll();
-            for (Purchase purchase : all) {
-                System.out.println(purchase.getTicket().getId() + " " + purchase.getMember().getId());
-            }
-
-            System.out.println("loginMember.getId() : " + loginMember.getId());
-            System.out.println("ticket.getId() : " + ticket.getId());
-
             MyPurchasedTicketResponse myPurchasedTicket = myService.findMyPurchasedTicket(loginMember.getId(), ticket.getId());
 
             // Then

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.domain.my.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
@@ -10,7 +11,15 @@ import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.domain.my.dto.MyPurchasedTicketResponse;
+import com.wootecam.festivals.domain.purchase.entity.Purchase;
+import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
+import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
+import com.wootecam.festivals.domain.purchase.repository.PurchaseRepository;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.constants.GlobalConstants;
+import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.global.page.CursorBasedPage;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
@@ -28,15 +37,20 @@ class MyServiceTest extends SpringBootTestConfig {
     private final MyService myService;
     private final FestivalRepository festivalRepository;
     private final MemberRepository memberRepository;
+    private final TicketRepository ticketRepository;
+    private final PurchaseRepository purchaseRepository;
 
     private Member admin;
 
     @Autowired
     public MyServiceTest(MyService myService, FestivalRepository festivalRepository,
-                         MemberRepository memberRepository) {
+                         MemberRepository memberRepository, TicketRepository ticketRepository,
+                         PurchaseRepository purchaseRepository) {
         this.myService = myService;
         this.festivalRepository = festivalRepository;
         this.memberRepository = memberRepository;
+        this.ticketRepository = ticketRepository;
+        this.purchaseRepository = purchaseRepository;
     }
 
     @BeforeEach
@@ -162,6 +176,124 @@ class MyServiceTest extends SpringBootTestConfig {
                     )
                     .map(festivalRepository::save)
                     .toList();
+        }
+    }
+
+    @Nested
+    @DisplayName("내가 구매한 티켓 단건 요청 시")
+    class Describe_findMyPurchasedTickets {
+
+        private Festival festival;
+        private Ticket ticket;
+        private Purchase purchase;
+        private Member loginMember;
+
+        @BeforeEach
+        void setup() {
+            loginMember = createMember("loginMember");
+            festival = createFestival(loginMember);
+            ticket = createTicket(festival);
+        }
+
+        @Test
+        @DisplayName("사용자가 구매한 티켓 목록을 반환한다.")
+        void it_returns_my_purchased_ticket_list() {
+            // When
+            purchase = createPurchase(ticket);
+
+            System.out.println("구매");
+            List<Purchase> all = purchaseRepository.findAll();
+            for (Purchase purchase : all) {
+                System.out.println(purchase.getTicket().getId() + " " + purchase.getMember().getId());
+            }
+
+            System.out.println("loginMember.getId() : " + loginMember.getId());
+            System.out.println("ticket.getId() : " + ticket.getId());
+
+            MyPurchasedTicketResponse myPurchasedTicket = myService.findMyPurchasedTicket(loginMember.getId(), ticket.getId());
+
+            // Then
+            assertAll(
+                    () -> assertThat(myPurchasedTicket.purchaseId()).isEqualTo(purchase.getId()),
+                    () -> assertThat(myPurchasedTicket.purchaseTime()).isEqualTo(purchase.getPurchaseTime()),
+                    () -> assertThat(myPurchasedTicket.purchaseStatus()).isEqualTo(purchase.getPurchaseStatus()),
+                    () -> assertThat(myPurchasedTicket.ticket().id()).isEqualTo(ticket.getId()),
+                    () -> assertThat(myPurchasedTicket.ticket().name()).isEqualTo(ticket.getName()),
+                    () -> assertThat(myPurchasedTicket.ticket().detail()).isEqualTo(ticket.getDetail()),
+                    () -> assertThat(myPurchasedTicket.ticket().price()).isEqualTo(ticket.getPrice()),
+                    () -> assertThat(myPurchasedTicket.ticket().quantity()).isEqualTo(ticket.getQuantity()),
+                    () -> assertThat(myPurchasedTicket.ticket().startSaleTime()).isEqualTo(ticket.getStartSaleTime()),
+                    () -> assertThat(myPurchasedTicket.ticket().endSaleTime()).isEqualTo(ticket.getEndSaleTime()),
+                    () -> assertThat(myPurchasedTicket.ticket().refundEndTime()).isEqualTo(ticket.getRefundEndTime()),
+                    () -> assertThat(myPurchasedTicket.festival().festivalId()).isEqualTo(festival.getId()),
+                    () -> assertThat(myPurchasedTicket.festival().adminId()).isEqualTo(festival.getAdmin().getId()),
+                    () -> assertThat(myPurchasedTicket.festival().title()).isEqualTo(festival.getTitle()),
+                    () -> assertThat(myPurchasedTicket.festival().description()).isEqualTo(festival.getDescription()),
+                    () -> assertThat(myPurchasedTicket.festival().startTime()).isEqualTo(festival.getStartTime()),
+                    () -> assertThat(myPurchasedTicket.festival().endTime()).isEqualTo(festival.getEndTime()),
+                    () -> assertThat(myPurchasedTicket.festival().festivalPublicationStatus()).isEqualTo(
+                            festival.getFestivalPublicationStatus()),
+                    () -> assertThat(myPurchasedTicket.festival().festivalProgressStatus()).isEqualTo(
+                            festival.getFestivalProgressStatus())
+            );
+        }
+
+        @Test
+        @DisplayName("사용자가 구매한 티켓이 없다면 예외를 던진다")
+        void it_returns_empty_list_for_empty_result() {
+            // When
+            assertThatThrownBy(() -> myService.findMyPurchasedTicket(loginMember.getId(), ticket.getId()))
+                    .isInstanceOf(ApiException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", PurchaseErrorCode.PURCHASE_NOT_FOUND);
+        }
+
+        private Festival createFestival(Member admin) {
+            LocalDateTime now = LocalDateTime.now();
+            return festivalRepository.save(
+                    Festival.builder()
+                            .admin(admin)
+                            .title("페스티벌")
+                            .description("페스티벌 설명")
+                            .startTime(now.plusDays(1))
+                            .endTime(now.plusDays(8))
+                            .festivalPublicationStatus(FestivalPublicationStatus.PUBLISHED)
+                            .build()
+            );
+        }
+
+        // 페스티벌 하나당 한 개의 티켓을 가지는 것으로 가정
+        private Ticket createTicket(Festival festival) {
+            return ticketRepository.save(
+                    Ticket.builder()
+                            .festival(festival)
+                            .name("티켓")
+                            .detail("티켓 설명")
+                            .price(10000L)
+                            .quantity(100)
+                            .startSaleTime(festival.getStartTime().plusHours(1))
+                            .endSaleTime(festival.getEndTime().minusHours(1))
+                            .refundEndTime(festival.getEndTime().minusHours(1))
+                            .build()
+            );
+        }
+
+        private Purchase createPurchase(Ticket ticket) {
+            return purchaseRepository.save(
+                    Purchase.builder()
+                            .ticket(ticket)
+                            .member(loginMember)
+                            .purchaseTime(LocalDateTime.now())
+                            .purchaseStatus(PurchaseStatus.PURCHASED)
+                            .build()
+            );
+        }
+
+        private Member createMember(String name) {
+            return memberRepository.save(Member.builder()
+                    .name(name)
+                    .email(name + "@test.com")
+                    .profileImg("profileImg")
+                    .build());
         }
     }
 }


### PR DESCRIPTION
## 📄 작업 설명
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/297e7a45-c66d-43d9-9aef-3fe5a056f77e">
<img width="334" alt="image" src="https://github.com/user-attachments/assets/a6109b2b-a4c1-476c-8802-bec6198a7c1c">

내가 구매한 티켓 목록 조회 후 그 중에서 특정 티켓의 상세 정보를 확인하는 API 입니다. 해당 API 에는 Festival, Purchase, Ticket 3 가지 정보가 들어가있어요.

## 🚨 관련 이슈
closes #75 

## 🌈 작업 상황
- DTO projection 통해 한번에 여러 테이블의 정보를 fetch 해오도록 함
- 서비스, 컨트롤러 로직 작성
- 테스트 코드, 명세서 작성
- 민지님이랑 같은 패키지 작업 중입니다. 민지님 머지되면 그 다음에 머지할게요!
