### PR TITLE
feat#74/ 내가 구매한 페스티벌 목록 조회

### DIFF
--- a/src/docs/asciidoc/api/domain/my/my.adoc
+++ b/src/docs/asciidoc/api/domain/my/my.adoc
@@ -22,3 +22,14 @@ include::{snippets}/my-controller-test/find-my-purchased-ticket/http-request.ado
 
 include::{snippets}/my-controller-test/find-my-purchased-ticket/http-response.adoc[]
 include::{snippets}/my-controller-test/find-my-purchased-ticket/response-fields-data.adoc[]
+
+=== 내가 구매한 티켓 목록 조회 API
+
+==== 성공
+
+include::{snippets}/my-controller-test/find-my-purchased-festivals/http-request.adoc[]
+
+===== HTTP Response
+
+include::{snippets}/my-controller-test/find-my-purchased-festivals/http-response.adoc[]
+include::{snippets}/my-controller-test/find-my-purchased-festivals/response-fields-data.adoc[]

--- a/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/controller/MyController.java
@@ -4,6 +4,7 @@ package com.wootecam.festivals.domain.my.controller;
 import com.wootecam.festivals.domain.my.dto.MyFestivalCursor;
 import com.wootecam.festivals.domain.my.dto.MyFestivalRequestParams;
 import com.wootecam.festivals.domain.my.dto.MyFestivalResponse;
+import com.wootecam.festivals.domain.my.dto.MyPurchasedFestivalResponse;
 import com.wootecam.festivals.domain.my.dto.MyPurchasedTicketResponse;
 import com.wootecam.festivals.domain.my.service.MyService;
 import com.wootecam.festivals.global.api.ApiResponse;
@@ -66,5 +67,26 @@ public class MyController {
         log.debug("내가 구매한 티켓 조회 완료 - ticketId: {}", ticketId);
 
         return ApiResponse.of(myPurchasedTicketResponse);
+    }
+
+    /**
+     * 사용자가 구매한 축제 목록을 조회합니다.
+     *
+     * @param loginMemberId 조회할 사용자 ID
+     * @param cursorTime    이전 페이지의 마지막 구매 시간 (yyyy-MM-dd'T'HH:mm 형식)
+     * @param cursorId      이전 페이지의 마지막 구매 ID
+     * @return 사용자가 구매한 축제 목록
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/tickets")
+    public ApiResponse<CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor>> findMyPurchasedFestivals(
+            @AuthUser Authentication authentication,
+            @Valid @ModelAttribute MyFestivalRequestParams params) {
+        log.debug("내가 구매한 축제 목록 조회 요청 - time: {}, id: {}", params.time(), params.id());
+        CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor> myPurchasedFestivalPage = myService.findMyPurchasedFestivals(
+                authentication.memberId(), new MyFestivalCursor(params.time(), params.id()), params.pageSize());
+        log.debug("내가 구매한 축제 목록 조회 완료 - 조회된 축제 수: {}", myPurchasedFestivalPage.getContent().size());
+
+        return ApiResponse.of(myPurchasedFestivalPage);
     }
 }

--- a/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedFestivalResponse.java
+++ b/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedFestivalResponse.java
@@ -1,0 +1,24 @@
+package com.wootecam.festivals.domain.my.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.wootecam.festivals.domain.festival.dto.FestivalAdminResponse;
+import com.wootecam.festivals.domain.festival.entity.FestivalProgressStatus;
+import com.wootecam.festivals.domain.festival.entity.FestivalPublicationStatus;
+import com.wootecam.festivals.global.utils.CustomLocalDateTimeSerializer;
+import java.time.LocalDateTime;
+
+public record MyPurchasedFestivalResponse(
+        String title,
+        String festivalImg,
+        @JsonSerialize(using = CustomLocalDateTimeSerializer.class)
+        LocalDateTime startTime,
+        @JsonSerialize(using = CustomLocalDateTimeSerializer.class)
+        LocalDateTime endTime,
+        FestivalPublicationStatus festivalPublicationStatus,
+        FestivalProgressStatus festivalProgressStatus,
+        FestivalAdminResponse admin,
+        Long purchaseId,
+        @JsonSerialize(using = CustomLocalDateTimeSerializer.class)
+        LocalDateTime purchaseTime
+){
+}

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -40,7 +40,7 @@ class MyServiceTest extends SpringBootTestConfig {
     private final TicketRepository ticketRepository;
     private final PurchaseRepository purchaseRepository;
 
-    private Member admin;
+    private Member loginMember;
 
     @Autowired
     public MyServiceTest(MyService myService, FestivalRepository festivalRepository,
@@ -57,7 +57,7 @@ class MyServiceTest extends SpringBootTestConfig {
     void setUp() {
         clear();
 
-        admin = memberRepository.save(
+        loginMember = memberRepository.save(
                 Member.builder()
                         .name("Test Admin")
                         .email("Test Detail")
@@ -73,7 +73,7 @@ class MyServiceTest extends SpringBootTestConfig {
         @DisplayName("커서가 없다면 사용자가 개최한 축제 목록의 첫 페이지를 반환한다.")
         void it_returns_my_festival_list_first_page() {
             // Given
-            Long loginMemberId = admin.getId();
+            Long loginMemberId = loginMember.getId();
             int count = 15;
             List<Festival> festivals = createFestivals(count);
 
@@ -97,7 +97,7 @@ class MyServiceTest extends SpringBootTestConfig {
         @DisplayName("커서가 있다면 사용자가 개최한 축제 목록 중 커서의 다음 페이지를 반환한다.")
         void it_returns_my_festival_list_next_page() {
             // Given
-            Long loginMemberId = admin.getId();
+            Long loginMemberId = loginMember.getId();
             int count = 25;
             List<Festival> festivals = createFestivals(count);
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> firstPage = myService.findHostedFestival(
@@ -124,7 +124,7 @@ class MyServiceTest extends SpringBootTestConfig {
         @DisplayName("개최한 축제가 없다면 빈 리스트와 null 커서를 반환한다.")
         void it_returns_empty_list_and_null_cursor_for_empty_result() {
             // Given
-            Long loginMemberId = admin.getId();
+            Long loginMemberId = loginMember.getId();
 
             // When
             CursorBasedPage<MyFestivalResponse, MyFestivalCursor> response = myService.findHostedFestival(loginMemberId,
@@ -142,7 +142,7 @@ class MyServiceTest extends SpringBootTestConfig {
         @DisplayName("페이지 크기가 전체 결과보다 크다면 모든 결과를 반환하고 다음 페이지가 없음을 표시한다.")
         void it_returns_all_results_when_page_size_is_larger() {
             // Given
-            Long loginMemberId = admin.getId();
+            Long loginMemberId = loginMember.getId();
             int count = 5;
             List<Festival> festivals = createFestivals(count);
 
@@ -166,7 +166,7 @@ class MyServiceTest extends SpringBootTestConfig {
             LocalDateTime now = LocalDateTime.now();
             return IntStream.range(1, count + 1)
                     .mapToObj(i -> Festival.builder()
-                            .admin(admin)
+                            .admin(loginMember)
                             .title("페스티벌 " + i)
                             .description("페스티벌 설명 " + i)
                             .startTime(now.plusDays(i + 1))
@@ -186,11 +186,9 @@ class MyServiceTest extends SpringBootTestConfig {
         private Festival festival;
         private Ticket ticket;
         private Purchase purchase;
-        private Member loginMember;
 
         @BeforeEach
         void setup() {
-            loginMember = createMember("loginMember");
             festival = createFestival(loginMember);
             ticket = createTicket(festival);
         }

--- a/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -2,6 +2,7 @@ package com.wootecam.festivals.domain.my.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
@@ -24,6 +25,7 @@ import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.global.page.CursorBasedPage;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +33,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
 
 @DisplayName("MyService 통합 테스트")
 class MyServiceTest extends SpringBootTestConfig {
@@ -206,22 +207,22 @@ class MyServiceTest extends SpringBootTestConfig {
             // Then
             assertAll(
                     () -> assertThat(myPurchasedTicket.purchaseId()).isEqualTo(purchase.getId()),
-                    () -> assertThat(myPurchasedTicket.purchaseTime()).isEqualTo(purchase.getPurchaseTime()),
+                    () -> assertThat(myPurchasedTicket.purchaseTime()).isCloseTo(purchase.getPurchaseTime(), within(59, ChronoUnit.SECONDS)),
                     () -> assertThat(myPurchasedTicket.purchaseStatus()).isEqualTo(purchase.getPurchaseStatus()),
                     () -> assertThat(myPurchasedTicket.ticket().id()).isEqualTo(ticket.getId()),
                     () -> assertThat(myPurchasedTicket.ticket().name()).isEqualTo(ticket.getName()),
                     () -> assertThat(myPurchasedTicket.ticket().detail()).isEqualTo(ticket.getDetail()),
                     () -> assertThat(myPurchasedTicket.ticket().price()).isEqualTo(ticket.getPrice()),
                     () -> assertThat(myPurchasedTicket.ticket().quantity()).isEqualTo(ticket.getQuantity()),
-                    () -> assertThat(myPurchasedTicket.ticket().startSaleTime()).isEqualTo(ticket.getStartSaleTime()),
-                    () -> assertThat(myPurchasedTicket.ticket().endSaleTime()).isEqualTo(ticket.getEndSaleTime()),
-                    () -> assertThat(myPurchasedTicket.ticket().refundEndTime()).isEqualTo(ticket.getRefundEndTime()),
+                    () -> assertThat(myPurchasedTicket.ticket().startSaleTime()).isCloseTo(ticket.getStartSaleTime(), within(59, ChronoUnit.SECONDS)),
+                    () -> assertThat(myPurchasedTicket.ticket().endSaleTime()).isCloseTo(ticket.getEndSaleTime(), within(59, ChronoUnit.SECONDS)),
+                    () -> assertThat(myPurchasedTicket.ticket().refundEndTime()).isCloseTo(ticket.getRefundEndTime(), within(59, ChronoUnit.SECONDS)),
                     () -> assertThat(myPurchasedTicket.festival().festivalId()).isEqualTo(festival.getId()),
                     () -> assertThat(myPurchasedTicket.festival().adminId()).isEqualTo(festival.getAdmin().getId()),
                     () -> assertThat(myPurchasedTicket.festival().title()).isEqualTo(festival.getTitle()),
                     () -> assertThat(myPurchasedTicket.festival().description()).isEqualTo(festival.getDescription()),
-                    () -> assertThat(myPurchasedTicket.festival().startTime()).isEqualTo(festival.getStartTime()),
-                    () -> assertThat(myPurchasedTicket.festival().endTime()).isEqualTo(festival.getEndTime()),
+                    () -> assertThat(myPurchasedTicket.festival().startTime()).isCloseTo(festival.getStartTime(), within(59, ChronoUnit.SECONDS)),
+                    () -> assertThat(myPurchasedTicket.festival().endTime()).isCloseTo(festival.getEndTime(), within(59, ChronoUnit.SECONDS)),
                     () -> assertThat(myPurchasedTicket.festival().festivalPublicationStatus()).isEqualTo(
                             festival.getFestivalPublicationStatus()),
                     () -> assertThat(myPurchasedTicket.festival().festivalProgressStatus()).isEqualTo(


### PR DESCRIPTION
## 📄 작업 설명
<img width="442" alt="image" src="https://github.com/user-attachments/assets/a53d5b6e-0be6-43c1-8355-25b86adbaacf">

마이페이지에서 내가 구매한 페스티벌 목록을 조회하는 API 이며 페이지네이션이 적용되어 있습니다.

## 🚨 관련 이슈
closes #74 

## 🌈 작업 상황
- LocalDateTime.max() 로 했을 때 jpql 이 제대로 작동이 안되는 이슈가 있었습니다. 그래서 현재 `LocalDateTime.of(3000, 12, 31, 0, 0)` 으로 설정을 해두었습니다. (이슈에 대해서는 좀더 찾아볼게요!)
- 페이지네이션에 쓰이는 커서 관련해서 리팩토링이 필요한 상황입니다. `LocalDateTime.of(3000, 12, 31, 0, 0)` 와 같이 커서가 들어오지 않을 경우에 임의로 큰 값을 넣어주는데 이건 리팩토링 과정에서 클래스 안으로 넣을게요!
- 아직 머지되지 않은 것들 때문에 다른 pr 들과 커밋이 겹쳐서 들어가고 있어요. #63 #75 순서대로 먼저 커밋되고 나서 머지하겠습니다!