### PR TITLE
config#91/DDL 정의 및 더미 데이터 생성

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - redis
       - mysql
     environment:
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: local
     volumes:
       - ./src/main/resources/application.yml:/app/application.yml
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/backend/src/main/resources/data/ddl.sql
+++ b/backend/src/main/resources/data/ddl.sql
@@ -1,0 +1,89 @@
+drop table if exists checkin;
+drop table if exists festival;
+drop table if exists member;
+drop table if exists purchase;
+drop table if exists ticket;
+drop table if exists ticket_stock;
+
+create table checkin
+(
+    is_checked   bit    not null,
+    checkin_id   bigint not null auto_increment,
+    checkin_time datetime(6),
+    created_at   datetime(6) not null,
+    festival_id  bigint not null,
+    member_id    bigint not null,
+    ticket_id    bigint not null,
+    updated_at   datetime(6) not null,
+    primary key (checkin_id)
+) engine=InnoDB;
+
+create table festival
+(
+    is_deleted                  bit           not null,
+    admin_id                    bigint        not null,
+    created_at                  datetime(6) not null,
+    festival_end_time           datetime not null,
+    festival_id                 bigint        not null auto_increment,
+    festival_start_time         datetime not null,
+    updated_at                  datetime(6) not null,
+    festival_title              varchar(100)  not null,
+    festival_description        varchar(2000) not null,
+    festival_img                varchar(255),
+    festival_progress_status    enum ('COMPLETED','ONGOING','UPCOMING') not null,
+    festival_publication_status enum ('DRAFT','PUBLISHED') not null,
+    primary key (festival_id)
+) engine=InnoDB;
+
+create table member
+(
+    is_deleted  bit          not null,
+    created_at  datetime(6) not null,
+    member_id   bigint       not null auto_increment,
+    updated_at  datetime(6) not null,
+    email       varchar(255) not null unique,
+    member_name varchar(255) not null,
+    profile_img varchar(255),
+    primary key (member_id)
+) engine=InnoDB;
+
+create table purchase
+(
+    created_at      datetime(6) not null,
+    member_id       bigint not null,
+    purchase_id     bigint not null auto_increment,
+    purchase_time   datetime(6) not null,
+    ticket_id       bigint not null,
+    updated_at      datetime(6) not null,
+    purchase_status enum ('PURCHASED','REFUNDED') not null,
+    primary key (purchase_id)
+) engine=InnoDB;
+
+create table ticket
+(
+    ticket_id       bigint       not null auto_increment,
+    is_deleted      bit          not null,
+    ticket_quantity integer      not null,
+    created_at      datetime(6) not null,
+    end_refund_time datetime not null,
+    end_sale_time   datetime not null,
+    festival_id     bigint       not null,
+    start_sale_time datetime not null,
+    ticket_price    bigint       not null,
+    updated_at      datetime(6) not null,
+    ticket_detail   varchar(255) not null,
+    ticket_name     varchar(255) not null,
+
+    primary key (ticket_id)
+) engine=InnoDB;
+
+create table ticket_stock
+(
+    ticket_purchase_id bigint  not null auto_increment,
+    ticket_stock       integer not null unique,
+    created_at         datetime(6) not null,
+    ticket_id          bigint  not null,
+    updated_at         datetime(6) not null,
+
+    primary key (ticket_purchase_id)
+) engine=InnoDB;


### PR DESCRIPTION
## 📄 작업 설명

현재까지 구현한 entity의 DDL을 정의하고, 더미 데이터를 생성하여 노션에 업로드했어요!
- 더미 데이터는 사용자 10만명, 페스티벌 1000개, 티켓 3000개를 포함해요!

## 🚨 관련 이슈
closes #91 

## 🌈 작업 상황
- DDL 스크립트 추가
- data.sql 노션에 업로드

## 📌 기타
