### PR TITLE
feat#85/모니터링 구축 및 도커 재설정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,32 +1,10 @@
-# First stage: Build the application
-FROM gradle:8.8-jdk17 AS build
+FROM bellsoft/liberica-openjdk-alpine:17.0.12
 
-# Set the working directory
+# 디렉토리 생성 및 이동
 WORKDIR /app
 
-# Copy the Gradle wrapper and build files
-COPY gradlew .
-COPY gradle gradle
+# 호스트 파일을 도커 컨테이너로 복사(실행 전 jar 파일 생성 필요)
+COPY ./build/libs/festivals-0.0.1-SNAPSHOT.jar .
 
-# Copy the project files
-COPY src src
-COPY build.gradle .
-COPY settings.gradle .
-
-# Build the project
-RUN ./gradlew build
-
-# Second stage: Create the runtime image
-FROM eclipse-temurin:17-jre-alpine
-
-# Create app directory
-RUN mkdir /app
-
-# Set working directory
-WORKDIR /app
-
-# Copy the JAR file from the build stage
-COPY --from=build /app/build/libs/*.jar app.jar
-
-# Command to run the application
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# 도커 컨테이너에서 실행할 명령어 JAR 파일 실행
+ENTRYPOINT ["java", "-jar", "festivals-0.0.1-SNAPSHOT.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,13 +27,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.session:spring-session-core'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // Jackson의 Java 8 날짜/시간 모듈
+
+    // 모니터링 및 관리
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -102,6 +102,7 @@ jacocoTestCoverageVerification {
                     '**/dto/**', // exclude dto package
                     '**/global/exception/**', // exclude exception package
                     '**/global/api/**', // exclude api package
+                    '**/global/config/**', // exclude config package
             ])
         }))
     }
@@ -137,6 +138,7 @@ jacocoTestReport {
                     '**/dto/**', // exclude dto package
                     '**/global/exception/**', // exclude exception package
                     '**/global/api/**', // exclude api package
+                    '**/global/config/**', // exclude config package
             ])
         }))
     }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - monitoring-network
 
   grafana:
-    image: grafana/grafana:main-ubuntu
+    image: hyeonjun0530/grafana:1.0
     container_name: grafana
     ports:
       - "9091:3000"
@@ -39,6 +39,8 @@ services:
     image: redis:latest
     ports:
       - "6379:6379"
+    networks:
+        - monitoring-network
 
   mysql:
     image: hyeonjun0530/team2-dari-mysql:1.0
@@ -53,6 +55,18 @@ services:
       - "9104:9104"
     volumes:
       - mysql-data:/var/lib/mysql
+    networks:
+      - monitoring-network
+
+  redis-exporter:
+    image: oliver006/redis_exporter
+    ports:
+      - 9121:9121
+    environment:
+      REDIS_ADDR: "redis:6379"
+      REDIS_USER: null
+    command:
+      - '--debug'
     networks:
         - monitoring-network
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,9 +9,21 @@ services:
       - redis
       - mysql
     environment:
-      SPRING_PROFILES_ACTIVE: local
+      SPRING_PROFILES_ACTIVE: docker
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
     volumes:
-      - ./src/main/resources/application.yml:/app/application.yml
+      - ./src/main/resources/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--web.enable-lifecycle'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: always
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring-network
 
   redis:
     image: redis:latest
@@ -32,3 +44,7 @@ services:
 
 volumes:
   mysql-data:
+
+networks:
+  monitoring-network:
+    driver: bridge

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - mysql
     environment:
       SPRING_PROFILES_ACTIVE: docker
+    networks:
+        - monitoring-network
 
   prometheus:
     image: prom/prometheus:latest
@@ -25,13 +27,21 @@ services:
     networks:
       - monitoring-network
 
+  grafana:
+    image: grafana/grafana:main-ubuntu
+    container_name: grafana
+    ports:
+      - "9091:3000"
+    networks:
+      - monitoring-network
+
   redis:
     image: redis:latest
     ports:
       - "6379:6379"
 
   mysql:
-    image: mysql:8.0.35
+    image: hyeonjun0530/team2-dari-mysql:1.0
     environment:
       MYSQL_ROOT_USER: root
       MYSQL_ALLOW_EMPTY_PASSWORD: yes
@@ -39,8 +49,12 @@ services:
       TZ: Asia/Seoul
     ports:
       - "3306:3306"
+      - "9100:9100"
+      - "9104:9104"
     volumes:
       - mysql-data:/var/lib/mysql
+    networks:
+        - monitoring-network
 
 volumes:
   mysql-data:

--- a/backend/src/main/java/com/wootecam/festivals/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wootecam/festivals/global/config/WebMvcConfig.java
@@ -26,9 +26,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns("**/public/**"
-                        , "/api/*/auth/login"
-                        , "/api/*/member/signup"
-                        , "**/error");
+                .excludePathPatterns("**/public/**",
+                        "/api/*/auth/login",
+                        "/api/*/member/signup",
+                        "**/error",
+                        "**/actuator/**");
     }
 }

--- a/backend/src/main/java/com/wootecam/festivals/global/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/com/wootecam/festivals/global/interceptor/AuthInterceptor.java
@@ -9,23 +9,24 @@ import com.wootecam.festivals.global.utils.AuthenticationUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Profile("!test")
 public class AuthInterceptor implements HandlerInterceptor {
 
-    private static Logger logger = LoggerFactory.getLogger(AuthInterceptor.class);
-
     private final MemberRepository memberRepository;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        log.debug("request uri: {}", request.getRequestURI());
         Authentication authentication = AuthenticationUtils.getAuthentication();
         validateAuthentication(authentication);
         return true;
@@ -34,7 +35,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     private void validateAuthentication(Authentication authentication) {
         if (authentication == null || !isValidAuthentication(authentication)) {
 
-            logger.error("Authentication is invalid {}", authentication);
+            log.error("Authentication is invalid {}", authentication);
 
             throw new ApiException(AuthErrorCode.UNAUTHORIZED);
         }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     jpa:
       hibernate:
-        ddl-auto: create
+        ddl-auto: none
       show-sql: true
       properties:
         hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,7 +1,9 @@
 spring:
   profiles:
-    active: local
-    include: secret
+    active: docker
+    include: secret, prometheus
+server:
+  port: 8080
 ---
 spring:
   config:
@@ -51,11 +53,51 @@ spring:
       redis:
         host: redis
         port: 6379
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+---
+spring:
+  config:
+    activate:
+      on-profile: docker
+  datasource:
+    url: jdbc:mysql://mysql:3306/twodari?useSSL=false&allowPublicKeyRetrieval=true
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+    com.wootecam.festivals: debug
 
-  server:
-    port: 8080
+# actuator, prometheus 설정
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
-  logging:
-    level:
-      org.hibernate.SQL: debug
-      org.hibernate.type: trace

--- a/backend/src/main/resources/prometheus.yml
+++ b/backend/src/main/resources/prometheus.yml
@@ -7,7 +7,7 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     scrape_interval: 15s
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets: ['spring-app:8080']
         labels:
           application: festival
   - job_name: linux_mysql

--- a/backend/src/main/resources/prometheus.yml
+++ b/backend/src/main/resources/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+    

--- a/backend/src/main/resources/prometheus.yml
+++ b/backend/src/main/resources/prometheus.yml
@@ -8,4 +8,12 @@ scrape_configs:
     scrape_interval: 15s
     static_configs:
       - targets: ['host.docker.internal:8080']
-    
+        labels:
+          application: festival
+  - job_name: linux_mysql
+    static_configs:
+      - targets: ['mysql:9100']
+  - job_name: mysql_mysql
+    static_configs:
+      - targets: ['mysql:9104']
+

--- a/backend/src/main/resources/prometheus.yml
+++ b/backend/src/main/resources/prometheus.yml
@@ -16,4 +16,8 @@ scrape_configs:
   - job_name: mysql_mysql
     static_configs:
       - targets: ['mysql:9104']
-
+  - job_name: redis-exporter
+    static_configs:
+      - targets: ['redis-exporter:9121']
+        labels:
+          application: redis


### PR DESCRIPTION
## 📄 작업 설명
모니터링 및 도커 파일을 다시 작성했어요 !
도커 파일은 기존 src를 복사해서 사용하는 방식과는 다르게 로컬에서 빌드 후 빠르게 jar만 복사해 jdk로 실행하는 로직으로 바꾸었어요.
이는 추후 EC2 CI/CD 과정에서 gradle 빌드와 src와 git을 가진 컨테이너를 커밋해 커스텀 이미지로 만들어서 사용할 수 있게 바꿀 예정입니다 !
그리고 모니터링 툴을 구축했어요 !
mysql은 cpu, memory를 수집하는 node-exporter와 mysql-exporter를 가진 커스텀 이미지이고, 
그라파나는 모니터링 툴 및 도커의 프로메테우스와 연결되어 있는 컨테이너 상태 그대로 커스텀 이미지로 만들어서 localhost:9091로 들어가시면 redis, mysql, spring, jvm 모니터링을 하실 수 있어요 !
redis는 exporter를 따로 붙여줬고, 추후 운영 환경에서는 각각의 exporter를 제외하지 않을까 싶네요 
application.yml 및 prometheus.yml도 바꾸었으니 확인 부탁드릴께요.
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/53d18271-df6f-492a-8401-8e4d0972c7ed">


그리고 기본적으로 redis를 쓰지 않는다면 mysql, prometheus, grafana 정도만 띄우고 스프링만 재빌드 하시면 됩니다 !
더 궁금한게 있다면 코멘트 달아주세요 👍 
## 🚨 관련 이슈
closes #85

## 🌈 작업 상황
- 도커파일 재작성
- 프로메테우스, 그라파나 모니터링 구축
- 추가 이미지 빌드
## 📌 기타
