### PR TITLE
feat#97/ 페스티벌 상세 조회, 목록 첫페이지 캐싱

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 ext {

--- a/backend/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
+++ b/backend/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -65,6 +66,7 @@ public class FestivalService {
      * @throws ApiException 축제를 찾을 수 없는 경우 발생
      */
     @Transactional(readOnly = true)
+    @Cacheable(value = "festival", key = "#festivalId", condition = "#festivalId != null")
     public FestivalResponse getFestivalDetail(Long festivalId) {
         Assert.notNull(festivalId, "Festival ID는 null일 수 없습니다.");
 

--- a/backend/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
+++ b/backend/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalService.java
@@ -95,7 +95,11 @@ public class FestivalService {
      * @return 축제 목록과 다음 페이지 커서 정보를 포함한 응답 DTO
      */
     @Transactional(readOnly = true)
-    public KeySetPageResponse<FestivalListResponse> getFestivals(LocalDateTime cursorTime,
+    @Cacheable(
+            value = "festivalsFirstPage",
+            key = "#cursorTime + '_' + #cursorId + '_' + #pageSize",
+            condition = "#cursorTime == null && #cursorId == null && #pageSize > 0"
+    )    public KeySetPageResponse<FestivalListResponse> getFestivals(LocalDateTime cursorTime,
                                                                  Long cursorId,
                                                                  int pageSize) {
         LocalDateTime now = DateTimeUtils.normalizeDateTime(LocalDateTime.now());

--- a/backend/src/main/java/com/wootecam/festivals/global/config/CacheConfig.java
+++ b/backend/src/main/java/com/wootecam/festivals/global/config/CacheConfig.java
@@ -14,14 +14,14 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("festival");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("festival", "festivalsFirstPage");
         cacheManager.setCaffeine(caffeineCacheBuilder());
         return cacheManager;
     }
 
     Caffeine<Object, Object> caffeineCacheBuilder() {
         return Caffeine.newBuilder()
-                .expireAfterWrite(1, TimeUnit.HOURS)
+                .expireAfterWrite(1, TimeUnit.MINUTES)
                 .maximumSize(100);
     }
 }

--- a/backend/src/main/java/com/wootecam/festivals/global/config/CacheConfig.java
+++ b/backend/src/main/java/com/wootecam/festivals/global/config/CacheConfig.java
@@ -1,0 +1,27 @@
+package com.wootecam.festivals.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("festival");
+        cacheManager.setCaffeine(caffeineCacheBuilder());
+        return cacheManager;
+    }
+
+    Caffeine<Object, Object> caffeineCacheBuilder() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(1, TimeUnit.HOURS)
+                .maximumSize(100);
+    }
+}

--- a/backend/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
+++ b/backend/src/test/java/com/wootecam/festivals/domain/festival/service/FestivalServiceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @DisplayName("FestivalService 통합 테스트")
@@ -46,6 +47,9 @@ class FestivalServiceTest extends SpringBootTestConfig {
     @Autowired
     private ThreadPoolTaskScheduler taskScheduler;
 
+    @Autowired
+    private CacheManager cacheManager;
+
     private Member admin;
 
     @BeforeEach
@@ -59,6 +63,9 @@ class FestivalServiceTest extends SpringBootTestConfig {
                         .email("Test Detail")
                         .profileImg("Test profileImg")
                         .build());
+
+        // cache 초기화
+        cacheManager.getCacheNames().forEach(cacheName -> cacheManager.getCache(cacheName).clear());
     }
 
     @Nested


### PR DESCRIPTION
## 📄 작업 설명
spring-cache 를 사용하여 페스티벌 상세 조회와 페스티벌 목록 조회 중 첫 페이지 캐싱하였습니다. 

## 🚨 관련 이슈
closes #97 

## 🌈 작업 상황
- 페스티벌 상세 조회
- 페스티벌 목록 첫 페이지 캐싱 (첫 페이지 요청 시 cursorTime == null && cursorId == null 임을 이용) 

### 카페인 캐시 고른 이유
해당 위키 참고하여 모든 면에서 성능이 좋음을 확인
https://github.com/ben-manes/caffeine/wiki/Benchmarks

### [페스티벌 상세 조회] 카페인 캐시 적용 전
![image](https://github.com/user-attachments/assets/7d75ad95-def6-41c3-a810-8129dc09c685)

### [페스티벌 상세 조회] 카페인 캐시 적용 후
![image](https://github.com/user-attachments/assets/98f6a025-c8ad-4df4-b399-1ab468af8599)

### 처리량 (Throughput)

캐시 적용 전: 837.72 요청/초
캐시 적용 후: 1076.71 요청/초
캐시 적용 후 처리량이 약 28.5% 증가

### 응답 시간

캐시 적용 전: 평균 3.23초, 중앙값 3.31초
캐시 적용 후: 평균 2.29초, 중앙값 2.34초
캐시 적용 후 응답 시간이 크게 감소했습니다. 평균 응답 시간이 약 29% 단축

테스트는 random 으로 페스티벌을 조회했기 때문에 실제 운영 환경에서는 cache hit 이 더 높아질 것으로 예상됨