### PR TITLE
fix#106/ hibernate 정보를 액츄에이터로 나타내기 위한 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     // 모니터링 및 관리
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.hibernate:hibernate-micrometer:6.6.0.Final'
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -45,7 +45,6 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
-    org.hibernate.type: trace
     com.wootecam.festivals: debug
 ---
 spring:
@@ -73,7 +72,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
-    org.hibernate.type: debug
+    com.wootecam.festivals: debug
 ---
 spring:
   config:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -73,7 +73,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
-    org.hibernate.type: trace
+    org.hibernate.type: debug
 ---
 spring:
   config:


### PR DESCRIPTION
## 📄 작업 설명
hibernate-micrometer 의존성이 빠져 로그 수집이 안되는 버그가 있었습니다.
따라서 hibernate-micrometer을 주입하고, yml에서 Prod 로깅을 Debug로 바꿨습니다.

## 🚨 관련 이슈
closes #106 

## 🌈 작업 상황
- hibernate 정보를 액츄에이터로 나타내기 위한 의존성 추가
- prod 환경 로깅 레벨 수정
## 📌 기타
