### PR TITLE
hotfix#117/ 내가 참여한 페스티벌 목록 조회 id, starttime null 체킹

### DIFF
--- a/backend/src/main/java/com/wootecam/festivals/domain/my/service/MyService.java
+++ b/backend/src/main/java/com/wootecam/festivals/domain/my/service/MyService.java
@@ -46,12 +46,12 @@ public class MyService {
     }
 
     public CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor> findMyPurchasedFestivals(Long loginMemberId, MyFestivalCursor cursor, int pageSize) {
-        LocalDateTime curosrTime = cursor == null ? LocalDateTime.of(3000, 12, 31, 0, 0) : cursor.startTime();
-        long cursorId = cursor == null ? Long.MAX_VALUE : cursor.id();
+        LocalDateTime cursorTime = cursor.startTime() == null ? LocalDateTime.of(3000, 12, 31, 0, 0) : cursor.startTime();
+        Long cursorId = cursor.id() == null ? Long.MAX_VALUE : cursor.id();
 
         List<MyPurchasedFestivalResponse> festivalDtos = purchaseRepository.findPurchasedFestivalsCursorOrderPurchaseTimeDesc(
                 loginMemberId,
-                curosrTime, // LocalDateTime.max() 를 넣으면 에러 발생
+                cursorTime, // LocalDateTime.max() 를 넣으면 에러 발생
                 cursorId,
                 Pageable.ofSize(pageSize + 1));
 

--- a/backend/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/backend/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -246,7 +246,7 @@ class MyServiceTest extends SpringBootTestConfig {
     class Describe_findMyPurchasedFestivals {
 
         @Test
-        @DisplayName("커서가 없다면 사용자가 구매한 축제 목록의 첫 페이지를 반환한다.")
+        @DisplayName("커서에 id 와 starttime 이 null 이라면 사용자가 구매한 축제 목록의 첫 페이지를 반환한다.")
         void it_returns_my_purchased_festival_list_first_page() {
             // Given
             int count = 15;

--- a/backend/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
+++ b/backend/src/test/java/com/wootecam/festivals/domain/my/service/MyServiceTest.java
@@ -254,7 +254,7 @@ class MyServiceTest extends SpringBootTestConfig {
 
             // When
             CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor> firstPage = myService.findMyPurchasedFestivals(
-                    loginMember.getId(), null, 10);
+                    loginMember.getId(), new MyFestivalCursor(null, null), 10);
 
             // Then
             assertAll(
@@ -276,7 +276,7 @@ class MyServiceTest extends SpringBootTestConfig {
             List<Festival> festivals = createFestivalsWithPurchasesAndTickets(count);
 
             CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor> firstPage = myService.findMyPurchasedFestivals(
-                    loginMember.getId(), null, GlobalConstants.MIN_PAGE_SIZE);
+                    loginMember.getId(), new MyFestivalCursor(null, null), GlobalConstants.MIN_PAGE_SIZE);
             MyFestivalCursor cursor = firstPage.getCursor();
 
             // When
@@ -300,7 +300,7 @@ class MyServiceTest extends SpringBootTestConfig {
         void it_returns_empty_list_and_null_cursor_for_empty_result() {
             // When
             CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor> response = myService.findMyPurchasedFestivals(
-                    loginMember.getId(), null, GlobalConstants.MIN_PAGE_SIZE);
+                    loginMember.getId(), new MyFestivalCursor(null, null), GlobalConstants.MIN_PAGE_SIZE);
 
             // Then
             assertAll(
@@ -319,7 +319,7 @@ class MyServiceTest extends SpringBootTestConfig {
 
             // When
             CursorBasedPage<MyPurchasedFestivalResponse, MyFestivalCursor> response = myService.findMyPurchasedFestivals(
-                    loginMember.getId(), null, GlobalConstants.MIN_PAGE_SIZE);
+                    loginMember.getId(), new MyFestivalCursor(null, null), GlobalConstants.MIN_PAGE_SIZE);
 
             // Then
             assertAll(


### PR DESCRIPTION
## 📄 작업 설명
id, starttime 이 null 인 경우에 대한 체킹이 제대로 이뤄지지않아 수정했습니다.

## 🚨 관련 이슈
closes #117 

## 🌈 작업 상황
cursor null 체킹을 cursor.id(), cursor.starttime() null 체킹으로 수정하였습니다. 