### PR TITLE
 fix#121/티켓 동시 구매 중 중복 구매하는 버그 픽스

### DIFF
--- a/backend/k6-monitoring/scripts/event-test.js
+++ b/backend/k6-monitoring/scripts/event-test.js
@@ -1,6 +1,5 @@
 import http from 'k6/http';
 import {check, group, sleep} from 'k6';
-import {randomIntBetween} from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 import exec from 'k6/execution';
 
 const MAX_USER = 500;
@@ -207,9 +206,7 @@ function purchaseTicket(festivalId, ticketId, sessionCookie, email) {
 
     if (!checkRes) {
         console.error('Purchase ticket failed:', response.status, response.body, email);
-        console.log(sessionCookie)
-    } else {
-        console.log("구매 성공: ", email)
+        console.log(sessionCookie, email)
     }
 
     return checkRes ? JSON.parse(response.body).data : null;
@@ -224,9 +221,8 @@ export async function setup() {
 
     // 사용자 로그인 및 세션 쿠키 획득
     const loggedInUsers = [];
-    for (let i = 0; i < usersToLogin; i++) {
-        const userIndex = randomIntBetween(1, totalUsers);
-        const email = `user${userIndex}@example.com`;
+    for (let i = 1; i <= usersToLogin; i++) {
+        const email = `user${i}@example.com`;
         const sessionCookie = await login(email);
         if (sessionCookie) {
             loggedInUsers.push({email, sessionCookie});


### PR DESCRIPTION
## 📄 작업 설명

한 티켓을 동시 구매하는 시나리오 스크립트에서 사용자가 한 티켓을 중복으로 구매하는 버그를 해결했어요!

## 🚨 관련 이슈
closes #121 

## 🌈 작업 상황

기존 랜덤 사용자로 로그인하는데, 이 때 중복된 사용자로 로그인하여 중복 구매하는 문제가 있었습니다.
랜덤 사용자로 로그인하지 않고, 인덱스 카운트를 올려 로그인하는 방식으로 수정하여 해결했습니다!

## 📌 기타
