### PR TITLE
refactor#115/spring 성능 개선

### DIFF
--- a/backend/api-server/src/main/java/com/wootecam/festivals/FestivalsApplication.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/FestivalsApplication.java
@@ -4,11 +4,13 @@ import com.wootecam.festivals.global.config.CloudConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(CloudConfiguration.class)
 @EnableScheduling
+@EnableAsync
 public class FestivalsApplication {
 
 	public static void main(String[] args) {

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/checkin/repository/CheckinRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/checkin/repository/CheckinRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface CheckinRepository extends JpaRepository<Checkin, Long> {
 
     @Query("""
-            SELECT c FROM Checkin c 
+            SELECT c.id FROM Checkin c 
             WHERE c.member.id = :memberId AND c.ticket.id = :ticketId
             """)
-    Optional<Checkin> findByMemberIdAndTicketId(Long memberId, Long ticketId);
+    Optional<Long> findByMemberIdAndTicketId(Long memberId, Long ticketId);
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/festival/repository/FestivalRepository.java
@@ -95,4 +95,6 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
                     WHERE f.id = :festivalId AND f.isDeleted = false
             """)
     Page<ParticipantResponse> findParticipantsWithPagination(Long festivalId, Pageable pageable);
+
+    boolean existsById(Long id);
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/entity/Purchase.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/entity/Purchase.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,11 +32,11 @@ public class Purchase extends BaseEntity {
     @Column(name = "purchase_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id", nullable = false, updatable = false)
     private Ticket ticket;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PaymentService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PaymentService.java
@@ -1,5 +1,7 @@
 package com.wootecam.festivals.domain.purchase.service;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -11,11 +13,12 @@ public class PaymentService {
     @Async
     public void pay(Long memberId, Long ticketId) {
         log.debug("결제 요청 - 회원 ID: {}, 티켓 ID: {}", memberId, ticketId);
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            return;
-        }
-        log.debug("결제 완료 - 회원 ID: {}, 티켓 ID: {}", memberId, ticketId);
+        CompletableFuture.runAsync(() -> {
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }).thenRun(() -> log.debug("결제 완료 - 회원 ID: {}, 티켓 ID: {}", memberId, ticketId));
     }
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/Ticket.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/Ticket.java
@@ -9,6 +9,7 @@ import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
 import com.wootecam.festivals.global.audit.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,7 +33,7 @@ public class Ticket extends BaseEntity {
     @Column(name = "ticket_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id", nullable = false, updatable = false)
     private Festival festival;
 

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
@@ -3,6 +3,7 @@ package com.wootecam.festivals.domain.ticket.entity;
 import com.wootecam.festivals.global.audit.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,7 +30,7 @@ public class TicketStock extends BaseEntity {
     @Column(name = "ticket_stock", nullable = false)
     private int remainStock;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id", nullable = false, updatable = false)
     private Ticket ticket;
 

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
@@ -12,7 +12,6 @@ import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -41,7 +40,7 @@ public class TicketService {
     public TicketIdResponse createTicket(Long festivalId, TicketCreateRequest request) {
         log.debug("티켓 생성 요청 - 축제 ID: {}", festivalId);
 
-        Festival festival = Optional.of(festivalRepository.getReferenceById(festivalId))
+        Festival festival = festivalRepository.findById(festivalId)
                 .orElseThrow(() -> {
                     log.warn("축제를 찾을 수 없음 - 축제 ID: {}", festivalId);
                     return new ApiException(FestivalErrorCode.FESTIVAL_NOT_FOUND);
@@ -67,6 +66,11 @@ public class TicketService {
      */
     public TicketListResponse getTickets(Long festivalId) {
         log.debug("티켓 목록 조회 요청 - 축제 ID: {}", festivalId);
+
+        if (!festivalRepository.existsById(festivalId)) {
+            log.warn("축제를 찾을 수 없음 - 축제 ID: {}", festivalId);
+            throw new ApiException(FestivalErrorCode.FESTIVAL_NOT_FOUND);
+        }
 
         List<TicketResponse> ticketsByFestivalIdWithRemainStock =
                 ticketRepository.findTicketsByFestivalIdWithRemainStock(festivalId);

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
@@ -12,6 +12,7 @@ import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class TicketService {
     public TicketIdResponse createTicket(Long festivalId, TicketCreateRequest request) {
         log.debug("티켓 생성 요청 - 축제 ID: {}", festivalId);
 
-        Festival festival = festivalRepository.findById(festivalId)
+        Festival festival = Optional.of(festivalRepository.getReferenceById(festivalId))
                 .orElseThrow(() -> {
                     log.warn("축제를 찾을 수 없음 - 축제 ID: {}", festivalId);
                     return new ApiException(FestivalErrorCode.FESTIVAL_NOT_FOUND);
@@ -66,16 +67,11 @@ public class TicketService {
      */
     public TicketListResponse getTickets(Long festivalId) {
         log.debug("티켓 목록 조회 요청 - 축제 ID: {}", festivalId);
-        Festival festival = festivalRepository.findById(festivalId)
-                .orElseThrow(() -> {
-                    log.warn("축제를 찾을 수 없음 - 축제 ID: {}", festivalId);
-                    return new ApiException(FestivalErrorCode.FESTIVAL_NOT_FOUND);
-                });
 
         List<TicketResponse> ticketsByFestivalIdWithRemainStock =
-                ticketRepository.findTicketsByFestivalIdWithRemainStock(festival.getId());
+                ticketRepository.findTicketsByFestivalIdWithRemainStock(festivalId);
         log.debug("티켓 목록: {}", ticketsByFestivalIdWithRemainStock);
 
-        return new TicketListResponse(festival.getId(), ticketsByFestivalIdWithRemainStock);
+        return new TicketListResponse(festivalId, ticketsByFestivalIdWithRemainStock);
     }
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/global/auth/Authentication.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/global/auth/Authentication.java
@@ -2,9 +2,9 @@ package com.wootecam.festivals.global.auth;
 
 import com.wootecam.festivals.domain.member.entity.Member;
 
-public record Authentication(Long memberId, String name, String email) {
+public record Authentication(Long memberId) {
 
     public static Authentication from(Member member) {
-        return new Authentication(member.getId(), member.getName(), member.getEmail());
+        return new Authentication(member.getId());
     }
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/global/interceptor/AuthInterceptor.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/global/interceptor/AuthInterceptor.java
@@ -8,10 +8,9 @@ import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.global.utils.AuthenticationUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -21,8 +20,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 @Profile("!test")
 public class AuthInterceptor implements HandlerInterceptor {
-
-    private final MemberRepository memberRepository;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -42,13 +39,6 @@ public class AuthInterceptor implements HandlerInterceptor {
     }
 
     private boolean isValidAuthentication(Authentication authentication) {
-        return memberRepository.findById(authentication.memberId())
-                .map(member -> isMatchingMember(authentication, member))
-                .orElse(false);
-    }
-
-    private boolean isMatchingMember(Authentication authentication, Member member) {
-        return authentication.email().equals(member.getEmail())
-                && authentication.name().equals(member.getName());
+        return authentication.memberId() != null;
     }
 }

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -1,7 +1,9 @@
 spring:
   profiles:
-    active: docker
+    active: local
     include: secret
+  jpa:
+    open-in-view: false
 server:
   port: 8080
 # actuator, prometheus 설정
@@ -29,6 +31,8 @@ spring:
     username: root
     password:
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
   jpa:
     hibernate:
       ddl-auto: none
@@ -42,10 +46,23 @@ spring:
     redis:
       host: localhost
       port: 6379
+  task:
+    execution:
+      pool:
+        core-size: 16   # 기본 스레드 풀 크기 (코어 수에 맞춤)
+        max-size: 100   # 최대 스레드 풀 크기
+        queue-capacity: 10000 # 큐의 최대 용량
 logging:
   level:
-    org.hibernate.SQL: debug
+    #    org.hibernate.SQL: debug
     com.wootecam.festivals: debug
+    org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: off
+server:
+  tomcat:
+    threads:
+      min-spare: 100
+      max: 100
+      max-queue-capacity: 100000
 ---
 spring:
   config:

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -32,11 +32,12 @@ spring:
     password:
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
-      maximum-pool-size: 20
+      maximum-pool-size: 50 # 최대 커넥션 수 커스텀하게 사용
+      minimum-idle: 50 # 최소 idle 커넥션 수 커스텀하게 사용
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
+      show-sql: true
     properties:
       hibernate:
         format_sql: true
@@ -49,20 +50,20 @@ spring:
   task:
     execution:
       pool:
-        core-size: 16   # 기본 스레드 풀 크기 (코어 수에 맞춤)
-        max-size: 100   # 최대 스레드 풀 크기
+        core-size: 75   # 기본 스프링 비동기 스레드 풀 크기 커스텀하게 사용 (CPU 점유율 확인)
+        max-size: 200   # 최대 스프링 비동기 스레드 풀 크기 커스텀하게 사용 (CPU 점유율 확인)
         queue-capacity: 10000 # 큐의 최대 용량
 logging:
   level:
-    #    org.hibernate.SQL: debug
-    com.wootecam.festivals: debug
+    org.hibernate.SQL: debug
+    com.wootecam.festivals: error
     org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: off
 server:
   tomcat:
     threads:
-      min-spare: 100
-      max: 100
-      max-queue-capacity: 100000
+      min-spare: 75 # 최소 톰캣 스레드 수 커스텀하게 사용 (CPU 점유율 확인)
+      max: 75 # 최대 톰캣 스레드 풀 크기 커스텀하게 사용 (CPU 점유율 확인)
+      max-queue-capacity: 10000
 ---
 spring:
   config:

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -37,10 +37,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-      show-sql: true
+#    show-sql: true
     properties:
       hibernate:
-        format_sql: true
+#        format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
         generate_statistics: true
   data:
@@ -55,7 +55,7 @@ spring:
         queue-capacity: 10000 # 큐의 최대 용량
 logging:
   level:
-    org.hibernate.SQL: debug
+    org.hibernate.SQL: off
     com.wootecam.festivals: error
     org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: off
 server:

--- a/backend/api-server/src/main/resources/data/ddl.sql
+++ b/backend/api-server/src/main/resources/data/ddl.sql
@@ -1,89 +1,113 @@
-drop table if exists checkin;
-drop table if exists festival;
-drop table if exists member;
-drop table if exists purchase;
-drop table if exists ticket;
-drop table if exists ticket_stock;
-
-create table checkin
+create table if not exists twodari.checkin
 (
-    is_checked   bit    not null,
-    checkin_id   bigint not null auto_increment,
-    checkin_time datetime(6),
+    is_checked   bit         not null,
+    checkin_id   bigint auto_increment
+        primary key,
+    checkin_time datetime(6) null,
     created_at   datetime(6) not null,
-    festival_id  bigint not null,
-    member_id    bigint not null,
-    ticket_id    bigint not null,
-    updated_at   datetime(6) not null,
-    primary key (checkin_id)
+    festival_id  bigint      not null,
+    member_id    bigint      not null,
+    ticket_id    bigint      not null,
+    updated_at   datetime(6) not null
 ) engine=InnoDB;
 
-create table festival
+create index checkin_festival_id_index
+    on twodari.checkin (festival_id);
+
+create index checkin_member_id_index
+    on twodari.checkin (member_id);
+
+create index checkin_ticket_id_index
+    on twodari.checkin (ticket_id);
+
+create table if not exists twodari.festival
 (
-    is_deleted                  bit           not null,
-    admin_id                    bigint        not null,
-    created_at                  datetime(6) not null,
-    festival_end_time           datetime not null,
-    festival_id                 bigint        not null auto_increment,
-    festival_start_time         datetime not null,
-    updated_at                  datetime(6) not null,
-    festival_title              varchar(100)  not null,
-    festival_description        varchar(2000) not null,
-    festival_img                varchar(255),
-    festival_progress_status    enum ('COMPLETED','ONGOING','UPCOMING') not null,
-    festival_publication_status enum ('DRAFT','PUBLISHED') not null,
-    primary key (festival_id)
+    is_deleted                  bit                                       not null,
+    admin_id                    bigint                                    not null,
+    created_at                  datetime(6)                               null,
+    festival_end_time           datetime(6)                               not null,
+    festival_id                 bigint auto_increment
+        primary key,
+    festival_start_time         datetime(6)                               not null,
+    updated_at                  datetime(6)                               null,
+    festival_title              varchar(100)                              not null,
+    festival_description        varchar(2000)                             not null,
+    festival_img                varchar(255)                              null,
+    festival_progress_status    enum ('COMPLETED', 'ONGOING', 'UPCOMING') not null,
+    festival_publication_status enum ('DRAFT', 'PUBLISHED')               not null
 ) engine=InnoDB;
 
-create table member
+create index FKdyfiny3xeeh1t7n7w3v30gyf7
+    on twodari.festival (admin_id);
+
+create index festival_admin_id_index
+    on twodari.festival (admin_id);
+
+create table if not exists twodari.member
 (
     is_deleted  bit          not null,
-    created_at  datetime(6) not null,
-    member_id   bigint       not null auto_increment,
-    updated_at  datetime(6) not null,
-    email       varchar(255) not null unique,
+    created_at  datetime(6)  null,
+    member_id   bigint auto_increment
+        primary key,
+    updated_at  datetime(6)  null,
+    email       varchar(255) not null,
     member_name varchar(255) not null,
-    profile_img varchar(255),
-    primary key (member_id)
+    profile_img varchar(255) null,
+    constraint UKmbmcqelty0fbrvxp1q58dn57t
+        unique (email)
 ) engine=InnoDB;
 
-create table purchase
+create table if not exists twodari.purchase
 (
-    created_at      datetime(6) not null,
-    member_id       bigint not null,
-    purchase_id     bigint not null auto_increment,
-    purchase_time   datetime(6) not null,
-    ticket_id       bigint not null,
-    updated_at      datetime(6) not null,
-    purchase_status enum ('PURCHASED','REFUNDED') not null,
-    primary key (purchase_id)
+    created_at      datetime(6)                    not null,
+    member_id       bigint                         not null,
+    purchase_id     bigint auto_increment
+        primary key,
+    purchase_time   datetime(6)                    not null,
+    ticket_id       bigint                         not null,
+    updated_at      datetime(6)                    not null,
+    purchase_status enum ('PURCHASED', 'REFUNDED') not null
 ) engine=InnoDB;
 
-create table ticket
+create index purchase_member_id_index
+    on twodari.purchase (member_id);
+
+create index purchase_member_id_index_2
+    on twodari.purchase (member_id);
+
+create index purchase_ticket_id_index
+    on twodari.purchase (ticket_id);
+
+create table if not exists twodari.ticket
 (
-    ticket_id       bigint       not null auto_increment,
     is_deleted      bit          not null,
-    ticket_quantity integer      not null,
-    created_at      datetime(6) not null,
-    end_refund_time datetime not null,
-    end_sale_time   datetime not null,
+    ticket_quantity int          not null,
+    created_at      datetime(6)  null,
+    end_refund_time datetime(6)  not null,
+    end_sale_time   datetime(6)  not null,
     festival_id     bigint       not null,
-    start_sale_time datetime not null,
+    start_sale_time datetime(6)  not null,
+    ticket_id       bigint auto_increment
+        primary key,
     ticket_price    bigint       not null,
-    updated_at      datetime(6) not null,
+    updated_at      datetime(6)  null,
     ticket_detail   varchar(255) not null,
-    ticket_name     varchar(255) not null,
-
-    primary key (ticket_id)
+    ticket_name     varchar(255) not null
 ) engine=InnoDB;
 
-create table ticket_stock
+create index ticket_festival_id_index
+    on twodari.ticket (festival_id);
+
+create table if not exists twodari.ticket_stock
 (
-    ticket_purchase_id bigint  not null auto_increment,
-    ticket_stock       integer not null,
+    ticket_purchase_id bigint auto_increment
+        primary key,
+    ticket_stock       int         not null,
     created_at         datetime(6) not null,
-    ticket_id          bigint  not null,
-    updated_at         datetime(6) not null,
-
-    primary key (ticket_purchase_id)
+    ticket_id          bigint      not null,
+    updated_at         datetime(6) not null
 ) engine=InnoDB;
+
+create index ticket_stock_ticket_id_index
+    on twodari.ticket_stock (ticket_id);
+

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/auth/service/AuthServiceTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/auth/service/AuthServiceTest.java
@@ -82,7 +82,7 @@ class AuthServiceTest extends SpringBootTestConfig {
         @DisplayName("이미 로그인되어 있다면 예외가 발생한다")
         void throwException_alreadyLogin() {
             // given
-            AuthenticationUtils.setAuthenticated(new Authentication(1L, "name", "test@example.com"));
+            AuthenticationUtils.setAuthenticated(new Authentication(1L));
 
             // when then
             assertThatThrownBy(() -> authService.login("email@example.com"));

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/member/controller/MemberControllerTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/member/controller/MemberControllerTest.java
@@ -72,7 +72,7 @@ class MemberControllerTest extends RestDocsSupport {
     @DisplayName("회원 탈퇴 API")
     void withdrawMember() throws Exception {
         MockHttpSession session = new MockHttpSession();
-        session.setAttribute("authentication", new Authentication(1L, "test name", "test@example.com"));
+        session.setAttribute("authentication", new Authentication(1L));
 
         mockMvc.perform(delete("/api/v1/member")
                         .session(session))

--- a/backend/api-server/src/test/java/com/wootecam/festivals/global/interceptor/AuthInterceptorTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/global/interceptor/AuthInterceptorTest.java
@@ -28,9 +28,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class AuthInterceptorTest {
 
     @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
     private HttpServletRequest request;
 
     @Mock
@@ -40,7 +37,7 @@ class AuthInterceptorTest {
 
     @BeforeEach
     void setUp() {
-        authInterceptor = new AuthInterceptor(memberRepository);
+        authInterceptor = new AuthInterceptor();
     }
 
     @Nested
@@ -60,52 +57,12 @@ class AuthInterceptorTest {
         @Test
         @DisplayName("유효한 인증 정보로 true를 반환한다")
         void returnsTrueWithValidAuthentication() {
-            Authentication auth = new Authentication(1L, "Test User", "test@example.com");
-
-            Member member = Member.builder()
-                    .email("test@example.com")
-                    .name("Test User")
-                    .build();
+            Authentication auth = new Authentication(1L);
 
             try (MockedStatic<AuthenticationUtils> authUtils = mockStatic(AuthenticationUtils.class)) {
                 authUtils.when(AuthenticationUtils::getAuthentication).thenReturn(auth);
-                when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 
                 assertTrue(authInterceptor.preHandle(request, response, null));
-            }
-        }
-
-        @Test
-        @DisplayName("회원 정보가 일치하지 않을 때 예외를 던진다")
-        void throwsExceptionWhenMemberInfoMismatch() {
-            Authentication auth = new Authentication(1L, "test@example.com", "Test User");
-            Member member = Member.builder()
-                    .email("wrong_email@example.com")
-                    .name("Wrong User")
-                    .build();
-
-            try (MockedStatic<AuthenticationUtils> authUtils = mockStatic(AuthenticationUtils.class)) {
-                authUtils.when(AuthenticationUtils::getAuthentication).thenReturn(auth);
-                when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-
-                ApiException exception = assertThrows(ApiException.class,
-                        () -> authInterceptor.preHandle(request, response, null));
-                assertEquals(AuthErrorCode.UNAUTHORIZED, exception.getErrorCode());
-            }
-        }
-
-        @Test
-        @DisplayName("회원이 존재하지 않을 때 예외를 던진다")
-        void throwsExceptionWhenMemberNotFound() {
-            Authentication auth = new Authentication(1L, "test@example.com", "Test User");
-
-            try (MockedStatic<AuthenticationUtils> authUtils = mockStatic(AuthenticationUtils.class)) {
-                authUtils.when(AuthenticationUtils::getAuthentication).thenReturn(auth);
-                when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-
-                ApiException exception = assertThrows(ApiException.class,
-                        () -> authInterceptor.preHandle(request, response, null));
-                assertEquals(AuthErrorCode.UNAUTHORIZED, exception.getErrorCode());
             }
         }
     }


### PR DESCRIPTION
## 📄 작업 설명
권한 로직에서 member 엔티티를 통째로 들고 와야할까? 했을 때 세션이니까 가져와서 서비스에서 FindBy해서 어차피 검증하니까 세션만 있으면 Authentication에 넣어주고 여기서 세션에서 가져온 memberId만 사용해서 실제 member 조회는 각 서비스 조회해서 사용하는 것이 좋겠다 !
라고 생각해 변경 했고, 테스트도 수정했어요.
ddl도 fk 부분에 인덱스 걸어줬고, 쓰레드 풀, 커넥션 풀 옵션 설정과 Osiv를 전체 프로필에 대해 제거 했습니다.
쿼리도 한번 씩 돌리면서 id만 참조하는 로직들을 getReferenceById로 변경했습니다.
그리고 pay 로직도 Thread.sleep으로 blocking으로 동작하는데 CompletableFuture로 처리해 개선했어요 !

아래는 i9 2.3GHz 8코어, 32GB DDR4 맥북 
75   # 기본 스프링 비동기 스레드 풀 크기 
200   # 최대 스프링 비동기 스레드 풀 크기
10000 # 스프링 큐의 최대 용량
75 # 최소 톰캣 스레드 수 커스텀하게 사용 (CPU 점유율 확인)
75 # 최대 톰캣 스레드 풀 크기 커스텀하게 사용 (CPU 점유율 확인)
max-queue-capacity: 10000
maximum-pool-size: 50 # 최대 커넥션 수
minimum-idle: 50 # 최소 idle 커넥션 수
inno_buffer_pool: 1GB
기준입니다.

[1,000명]
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/5e0c3a12-72db-4014-812f-d95ebd519b80">

[5,000명]

<img width="1614" alt="image" src="https://github.com/user-attachments/assets/2f54fd95-a841-4e05-9577-a3b131a4caf5">

## 🚨 관련 이슈
closes #115

## 🌈 작업 상황
- LAZY 로딩 체크
- Query 분석
-  FK 인덱스 및 사용 쿼리 분석 후 인덱스 설정
- OSIV false
- k6 테스트 및 동시성 이슈 체크
- 쓰레드 풀, 커넥션 풀 설정(로컬)
- Authentication 세션만 사용
## 📌 기타
