### PR TITLE
feat#124/티켓 재고 엔티티 변경

### DIFF
--- a/backend/api-server/Dockerfile
+++ b/backend/api-server/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /app
 COPY ./build/libs/festivals-0.0.1-SNAPSHOT.jar .
 
 # 도커 컨테이너에서 실행할 명령어 JAR 파일 실행
-ENTRYPOINT ["java", "-jar", "festivals-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "*.jar"]

--- a/backend/api-server/docker-compose.yml
+++ b/backend/api-server/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.27.1'
-
 services:
   spring-app:
     build: .

--- a/backend/api-server/docker-compose.yml
+++ b/backend/api-server/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - influxdb-storage:/var/lib/influxdb
     environment:
       - INFLUXDB_DB=k6
+    networks:
+      - monitoring-network
 
   redis:
     image: redis:latest

--- a/backend/api-server/docker-compose.yml
+++ b/backend/api-server/docker-compose.yml
@@ -83,6 +83,7 @@ services:
 
 volumes:
   mysql-data:
+  influxdb-storage:
 
 networks:
   monitoring-network:

--- a/backend/api-server/docker-compose.yml
+++ b/backend/api-server/docker-compose.yml
@@ -35,6 +35,15 @@ services:
     networks:
       - monitoring-network
 
+  influxdb:
+    image: influxdb:1.8
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb-storage:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=k6
+
   redis:
     image: redis:latest
     ports:

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/dto/PurchasableResponse.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/dto/PurchasableResponse.java
@@ -1,4 +1,4 @@
 package com.wootecam.festivals.domain.purchase.dto;
 
-public record PurchasableResponse(boolean purchasable) {
+public record PurchasableResponse(boolean purchasable, Long ticketStockId) {
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/dto/PurchasePreviewInfoResponse.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/dto/PurchasePreviewInfoResponse.java
@@ -12,7 +12,7 @@ public record PurchasePreviewInfoResponse(Long festivalId,
                                           String ticketDetail,
                                           Long ticketPrice,
                                           int ticketQuantity,
-                                          int remainTicketQuantity,
+                                          Long ticketStockId,
                                           @JsonSerialize(using = CustomLocalDateTimeSerializer.class)
                                           LocalDateTime endSaleTime) {
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeService.java
@@ -20,9 +20,9 @@ public class PurchaseFacadeService {
     private final PaymentService paymentService;
 
     @Transactional
-    public PurchaseTicketResponse purchaseTicket(Long memberId, Long festivalId, Long ticketId) {
+    public PurchaseTicketResponse purchaseTicket(Long memberId, Long festivalId, Long ticketId, Long ticketStockId) {
         log.debug("티켓 구매 요청 - 축제 ID: {}, 티켓 ID: {}, 회원 ID: {}", festivalId, ticketId, memberId);
-        PurchaseIdResponse purchaseResponse = purchaseService.createPurchase(ticketId, memberId, LocalDateTime.now());
+        PurchaseIdResponse purchaseResponse = purchaseService.createPurchase(ticketId, memberId, LocalDateTime.now(), ticketStockId);
         log.debug("티켓 구매 완료 - 구매 ID: {}", purchaseResponse.purchaseId());
 
         paymentService.pay(memberId, ticketId);

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -53,7 +53,7 @@ public class PurchaseService {
 
         Optional<TicketStock> optionalTicketStock = getTicketStockForUpdate(ticket);
 
-        if (optionalTicketStock.isEmpty() || optionalTicketStock.get().isReservation()) {
+        if (optionalTicketStock.isEmpty() || optionalTicketStock.get().isReserved()) {
             return new PurchasableResponse(false, null);
         }
 

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -15,6 +15,7 @@ import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,9 +35,9 @@ public class PurchaseService {
     private final TicketRepository ticketRepository;
 
     /**
-     * 티켓을 결제할 수 있는지 확인합니다.
-     * 티켓을 재고가 없다면 false인 PurchasableResponse을, 티켓 재고가 있다면 true인 PurchasableResponse을 반환합니다.
-     * 티켓 구매 시각이 아니거나, 이미 티켓을 구매했다면 예외를 발생시킵니다.
+     * 티켓을 결제할 수 있는지 확인합니다. 티켓을 재고가 없다면 false인 PurchasableResponse을, 티켓 재고가 있다면 true인 PurchasableResponse을 반환합니다. 티켓 구매
+     * 시각이 아니거나, 이미 티켓을 구매했다면 예외를 발생시킵니다.
+     *
      * @param ticketId
      * @param loginMemberId
      * @param now
@@ -50,13 +51,15 @@ public class PurchaseService {
         Member member = memberRepository.getReferenceById(loginMemberId);
         validFirstTicketPurchase(ticket, member);
 
-        TicketStock ticketStock = getTicketStockForUpdate(ticket);
-        if(ticketStock.isEmpty()) {
-            return new PurchasableResponse(false);
+        Optional<TicketStock> optionalTicketStock = getTicketStockForUpdate(ticket);
+
+        if (optionalTicketStock.isEmpty() || optionalTicketStock.get().isReservation()) {
+            return new PurchasableResponse(false, null);
         }
 
-        decreaseStock(ticketStock);
-        return new PurchasableResponse(true);
+        TicketStock ticketStock = optionalTicketStock.get();
+        reserveTicket(ticketStock, member.getId());
+        return new PurchasableResponse(true, ticketStock.getId());
     }
 
     /**
@@ -65,22 +68,23 @@ public class PurchaseService {
      * @param memberId
      * @param festivalId
      * @param ticketId
+     * @param ticketStockId
      * @return PurchasePreviewInfoResponse
      */
-    public PurchasePreviewInfoResponse getPurchasePreviewInfo(Long memberId, Long festivalId, Long ticketId) {
+    public PurchasePreviewInfoResponse getPurchasePreviewInfo(Long memberId, Long festivalId, Long ticketId,
+                                                              Long ticketStockId) {
         Ticket ticket = findTicketByIdAndFestivalId(ticketId, festivalId);
         validTicketPurchasableTime(LocalDateTime.now(), ticket);
 
         Member member = memberRepository.getReferenceById(memberId);
         validFirstTicketPurchase(ticket, member);
 
-        TicketStock ticketStock = getTicketStock(ticket);
-        validStockRemain(ticketStock);
+        TicketStock ticketStock = getTicketStock(festivalId, ticket, ticketStockId, memberId);
 
         return new PurchasePreviewInfoResponse(festivalId, ticket.getFestival().getTitle(),
                 ticket.getFestival().getFestivalImg(),
                 ticket.getId(), ticket.getName(), ticket.getDetail(), ticket.getPrice(), ticket.getQuantity(),
-                ticketStock.getRemainStock(),
+                ticketStock.getId(),
                 ticket.getEndSaleTime());
     }
 
@@ -93,40 +97,43 @@ public class PurchaseService {
      * @return 생성된 구매 내역 ID
      */
     @Transactional
-    public PurchaseIdResponse createPurchase(Long ticketId, Long loginMemberId, LocalDateTime now) {
+    public PurchaseIdResponse createPurchase(Long ticketId, Long loginMemberId, LocalDateTime now, Long ticketStockId) {
         Ticket ticket = findTicketById(ticketId);
         validTicketPurchasableTime(now, ticket);
 
         Member member = memberRepository.getReferenceById(loginMemberId);
         validFirstTicketPurchase(ticket, member);
 
-        validStockRemain(getTicketStock(ticket));
-
+        validReservationTicketStock(ticketStockId, ticketId, loginMemberId);
         Purchase newPurchase = purchaseRepository.save(ticket.createPurchase(member));
 
         log.debug("티켓 구매 완료 - 티켓 ID: {}, 회원 ID: {}, 구매 ID: {}", ticketId, loginMemberId, newPurchase.getId());
         return new PurchaseIdResponse(newPurchase.getId());
     }
 
-    private TicketStock getTicketStockForUpdate(Ticket ticket) {
-        return ticketStockRepository.findByTicketForUpdate(ticket)
-                .orElseThrow(() -> {
-                    log.warn("티켓 재고를 찾을 수 없음 - 티켓 ID: {}", ticket.getId());
-                    return new ApiException(TicketErrorCode.TICKET_STOCK_NOT_FOUND);
-                });
+    private Optional<TicketStock> getTicketStockForUpdate(Ticket ticket) {
+        return ticketStockRepository.findByTicketForUpdate(ticket.getId());
     }
 
-    private TicketStock getTicketStock(Ticket ticket) {
-        return ticketStockRepository.findByTicket(ticket)
+    private TicketStock getTicketStock(Long festivalId, Ticket ticket, Long ticketStockId, Long memberId) {
+        TicketStock ticketStock = ticketStockRepository.findByIdAndTicketIdAndMemberId(ticketStockId, ticket.getId(), memberId)
                 .orElseThrow(() -> {
-                    log.warn("티켓 재고를 찾을 수 없음 - 티켓 ID: {}", ticket.getId());
+                    log.warn("티켓 재고를 찾을 수 없습니다. 티켓 ID: {}, 페스티벌 ID: {}, 티켓 재고 ID: {}", ticket.getId(), festivalId,
+                            ticketStockId);
                     return new ApiException(TicketErrorCode.TICKET_STOCK_NOT_FOUND);
                 });
+
+        if (!ticketStock.getTicket().getId().equals(ticket.getId())) {
+            log.warn("티켓 재고가 일치하지 않음 - 티켓 ID: {}, 페스티벌 ID: {}, 티켓 재고 ID: {}", ticket.getId(), festivalId,
+                    ticketStockId);
+            throw new ApiException(TicketErrorCode.TICKET_STOCK_MISMATCH);
+        }
+        return ticketStock;
     }
 
-    private void decreaseStock(TicketStock ticketStock) {
+    private void reserveTicket(TicketStock ticketStock, Long buyerId) {
         try {
-            ticketStock.decreaseStock();
+            ticketStock.reserveTicket(buyerId);
         } catch (IllegalStateException e) {
             log.warn("티켓 재고 부족 - 티켓 ID: {}", ticketStock.getTicket().getId());
             throw new ApiException(TicketErrorCode.TICKET_STOCK_EMPTY);
@@ -147,19 +154,13 @@ public class PurchaseService {
         }
     }
 
-    private void validStockRemain(TicketStock ticketStock) {
-        if (ticketStock.isEmpty()) {
-            log.warn("티켓 재고 부족 - 티켓 ID: {}", ticketStock.getTicket().getId());
-            throw new ApiException(TicketErrorCode.TICKET_STOCK_EMPTY);
+    // 해당 유저가 점유한 티켓 재고가 있는지 확인하는 로직
+    private void validReservationTicketStock(Long ticketStockId, Long ticketId, Long memberId) {
+        if (!ticketStockRepository.existsByIdAndTicketIdAndMemberId(ticketStockId, ticketId, memberId)) {
+            log.warn("해당 유저의 티켓 재고를 찾을 수 없습니다. 티켓 ID: {}, 티켓 재고 ID: {}, 구매자 ID: {}", ticketId, ticketStockId,
+                    memberId);
+            throw new ApiException(TicketErrorCode.TICKET_STOCK_MISMATCH);
         }
-    }
-
-    private Ticket findTicketById(Long ticketId) {
-        return ticketRepository.findById(ticketId)
-                .orElseThrow(() -> {
-                    log.warn("티켓을 찾을 수 없습니다. 티켓 ID: {}", ticketId);
-                    return new ApiException(TicketErrorCode.TICKET_NOT_FOUND);
-                });
     }
 
     // 페스티벌 ID와 티켓 ID로 티켓을 찾는 메소드, join fetch를 사용하여 티켓과 페스티벌을 한번에 가져옴
@@ -167,6 +168,14 @@ public class PurchaseService {
         return ticketRepository.findByIdAndFestivalId(ticketId, festivalId)
                 .orElseThrow(() -> {
                     log.warn("티켓 또는 페스티벌을 찾을 수 없습니다. 티켓 ID: {}, 축제 ID: {}", ticketId, festivalId);
+                    return new ApiException(TicketErrorCode.TICKET_NOT_FOUND);
+                });
+    }
+
+    private Ticket findTicketById(Long ticketId) {
+        return ticketRepository.findById(ticketId)
+                .orElseThrow(() -> {
+                    log.warn("티켓을 찾을 수 없습니다. 티켓 ID: {}", ticketId);
                     return new ApiException(TicketErrorCode.TICKET_NOT_FOUND);
                 });
     }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/TicketStockRollbacker.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/TicketStockRollbacker.java
@@ -18,11 +18,10 @@ public class TicketStockRollbacker {
     private final TicketStockRepository ticketStockRepository;
 
     @Transactional
-    public void rollbackTicketStock(Long ticketId, int quantity) {
-        log.debug("티켓 재고 복구 - 티켓 ID: {}, 수량: {}", ticketId, quantity);
-        TicketStock ticketStock = ticketStockRepository.findByTicketForUpdate(
-                        ticketRepository.getReferenceById(ticketId))
+    public void rollbackTicketStock(Long ticketStockId) {
+        log.debug("티켓 재고 복구 - 티켓 재고 ID: {}", ticketStockId);
+        TicketStock ticketStock = ticketStockRepository.findByIdForUpdate(ticketStockId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 티켓의 재고 정보가 존재하지 않습니다."));
-        ticketStock.increaseStock(quantity);
+        ticketStock.cancelTicket();
     }
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketResponse.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/dto/TicketResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
  */
 public record TicketResponse(Long id,
                              String name, String detail,
-                             Long price, int quantity, int remainStock,
+                             Long price, int quantity, Long remainStock,
                              LocalDateTime startSaleTime, LocalDateTime endSaleTime,
                              LocalDateTime refundEndTime,
                              LocalDateTime createdAt, LocalDateTime updatedAt) {

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/Ticket.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/Ticket.java
@@ -17,6 +17,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -63,8 +66,8 @@ public class Ticket extends BaseEntity {
 
     @Builder
     private Ticket(Festival festival,
-                  String name, String detail, Long price, int quantity,
-                  LocalDateTime startSaleTime, LocalDateTime endSaleTime, LocalDateTime refundEndTime) {
+                   String name, String detail, Long price, int quantity,
+                   LocalDateTime startSaleTime, LocalDateTime endSaleTime, LocalDateTime refundEndTime) {
         validTicket(festival, name, detail, price, quantity, startSaleTime, endSaleTime, refundEndTime);
         this.festival = festival;
         this.name = name;
@@ -77,11 +80,16 @@ public class Ticket extends BaseEntity {
         this.isDeleted = false;
     }
 
-    public TicketStock createTicketStock() {
-        return TicketStock.builder()
-                .ticket(this)
-                .remainStock(quantity)
-                .build();
+    public List<TicketStock> createTicketStock() {
+        List<TicketStock> ticketStocks = new ArrayList<>();
+
+        for (int i = 0; i < quantity; i++) {
+            ticketStocks.add(TicketStock.builder()
+                    .ticket(this)
+                    .build());
+        }
+
+        return Collections.unmodifiableList(ticketStocks);
     }
 
     public Purchase createPurchase(Member member) {

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -27,31 +27,30 @@ public class TicketStock extends BaseEntity {
     @Column(name = "ticket_purchase_id")
     private Long id;
 
-    @Column(name = "ticket_stock", nullable = false)
-    private int remainStock;
+    @Column(name = "ticket_stock_member_id")
+    private Long memberId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ticket_id", nullable = false, updatable = false)
     private Ticket ticket;
 
     @Builder
-    private TicketStock(int remainStock, Ticket ticket) {
-        this.remainStock = remainStock;
+    private TicketStock(Ticket ticket) {
         this.ticket = Objects.requireNonNull(ticket, "티켓 정보는 필수입니다.");
     }
 
-    public void decreaseStock() {
-        if (remainStock <= 0) {
-            throw new IllegalStateException("재고가 없습니다.");
+    public boolean isReservation() {
+        return this.memberId != null;
+    }
+
+    public void reserveTicket(Long buyerId) {
+        if (this.memberId != null) {
+            throw new IllegalStateException("이미 판매된 티켓입니다.");
         }
-        --remainStock;
+        this.memberId = buyerId;
     }
 
-    public void increaseStock(int increaseQuantity) {
-        remainStock += increaseQuantity;
-    }
-
-    public boolean isEmpty() {
-        return remainStock <= 0;
+    public void cancelTicket() {
+        this.memberId = null;
     }
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
@@ -39,7 +39,7 @@ public class TicketStock extends BaseEntity {
         this.ticket = Objects.requireNonNull(ticket, "티켓 정보는 필수입니다.");
     }
 
-    public boolean isReservation() {
+    public boolean isReserved() {
         return this.memberId != null;
     }
 

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketStock.java
@@ -24,7 +24,7 @@ public class TicketStock extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ticket_purchase_id")
+    @Column(name = "ticket_stock_id")
     private Long id;
 
     @Column(name = "ticket_stock_member_id")

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/exception/TicketErrorCode.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/exception/TicketErrorCode.java
@@ -11,6 +11,7 @@ public enum TicketErrorCode implements ErrorCode, EnumType {
     TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TK-0001", "해당하는 티켓을 찾을 수 없습니다."),
     TICKET_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "TK-0002", "해당하는 티켓 재고를 찾을 수 없습니다."),
     TICKET_STOCK_EMPTY(HttpStatus.BAD_REQUEST, "TK-0003", "티켓 재고가 없습니다."),
+    TICKET_STOCK_MISMATCH(HttpStatus.BAD_REQUEST, "TK-0004","해당 티켓의 재고가 아닙니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketRepository.java
@@ -9,17 +9,17 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
-    @Query("SELECT t FROM Ticket t WHERE t.id = :ticketId AND t.isDeleted = false")
+    @Query("SELECT t FROM Ticket t WHERE t.id = :id AND t.isDeleted = false")
     @Override
-    Optional<Ticket> findById(Long ticketId);
+    Optional<Ticket> findById(Long id);
 
     @Query("""
             SELECT new com.wootecam.festivals.domain.ticket.dto.TicketResponse(
-                t.id, t.name, t.detail, t.price, t.quantity, ts.remainStock, 
+                t.id, t.name, t.detail, t.price, t.quantity, 
+                (SELECT count(ts.id) FROM TicketStock ts WHERE ts.ticket.id = t.id AND ts.memberId IS NOT NULL),
                 t.startSaleTime, t.endSaleTime, t.refundEndTime, t.createdAt, t.updatedAt
             ) 
             FROM Ticket t 
-            INNER JOIN TicketStock ts ON t.id = ts.ticket.id 
             WHERE t.festival.id = :festivalId AND t.isDeleted = false
             """)
     List<TicketResponse> findTicketsByFestivalIdWithRemainStock(Long festivalId);

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockJdbcRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockJdbcRepository.java
@@ -1,0 +1,34 @@
+package com.wootecam.festivals.domain.ticket.repository;
+
+import com.wootecam.festivals.domain.ticket.entity.TicketStock;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TicketStockJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveTicketStocks(List<TicketStock> ticketStocks) {
+        String sql = "INSERT INTO ticket_stock (ticket_id) VALUES (?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int index) throws SQLException {
+                TicketStock ticketStock = ticketStocks.get(index);
+                ps.setLong(1, ticketStock.getTicket().getId());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return ticketStocks.size();
+            }
+        });
+    }
+}

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockRepository.java
@@ -1,6 +1,5 @@
 package com.wootecam.festivals.domain.ticket.repository;
 
-import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import jakarta.persistence.LockModeType;
 import java.util.Optional;
@@ -10,9 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TicketStockRepository extends JpaRepository<TicketStock, Long> {
-
-    @Query("SELECT ts FROM TicketStock ts WHERE ts.ticket = :ticket")
-    Optional<TicketStock> findByTicket(Ticket ticket);
 
     @Query(value = "SELECT * FROM (\n"
             + "                  SELECT * FROM ticket_stock ts\n"
@@ -27,8 +23,10 @@ public interface TicketStockRepository extends JpaRepository<TicketStock, Long> 
     Optional<TicketStock> findByIdForUpdate(Long id);
 
     @Query("SELECT CASE WHEN COUNT(ts) > 0 THEN true ELSE false END FROM TicketStock ts WHERE ts.id = :id AND ts.memberId = :memberId AND ts.ticket.id = :ticketId")
-    boolean existsByIdAndTicketIdAndMemberId(@Param("id") Long id, @Param("ticketId") Long ticketId, @Param("memberId") Long memberId);
+    boolean existsByIdAndTicketIdAndMemberId(@Param("id") Long id, @Param("ticketId") Long ticketId,
+                                             @Param("memberId") Long memberId);
 
     @Query("SELECT ts FROM TicketStock ts WHERE ts.id = :id AND ts.memberId = :memberId AND ts.ticket.id = :ticketId")
-    Optional<TicketStock> findByIdAndTicketIdAndMemberId(@Param("id") Long id, @Param("ticketId") Long ticketId, @Param("memberId") Long memberId);
+    Optional<TicketStock> findByIdAndTicketIdAndMemberId(@Param("id") Long id, @Param("ticketId") Long ticketId,
+                                                         @Param("memberId") Long memberId);
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockRepository.java
@@ -20,7 +20,7 @@ public interface TicketStockRepository extends JpaRepository<TicketStock, Long> 
     @Query("SELECT ts FROM TicketStock ts WHERE ts.id = :id")
     Optional<TicketStock> findByIdForUpdate(Long id);
 
-    @Query("SELECT CASE WHEN COUNT(ts) > 0 THEN true ELSE false END FROM TicketStock ts WHERE ts.id = :id AND ts.memberId = :memberId AND ts.ticket.id = :ticketId")
+    @Query("SELECT CASE WHEN EXISTS (SELECT 1 FROM TicketStock ts WHERE ts.id = :id AND ts.memberId = :memberId AND ts.ticket.id = :ticketId) THEN true ELSE false END")
     boolean existsByIdAndTicketIdAndMemberId(@Param("id") Long id, @Param("ticketId") Long ticketId,
                                              @Param("memberId") Long memberId);
 

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketStockRepository.java
@@ -10,12 +10,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface TicketStockRepository extends JpaRepository<TicketStock, Long> {
 
-    @Query(value = "SELECT * FROM (\n"
-            + "                  SELECT * FROM ticket_stock ts\n"
-            + "                  WHERE ts.ticket_id = :#{#ticketId} AND ts.ticket_stock_member_id IS NULL\n"
-            + "                      FOR UPDATE SKIP LOCKED\n"
-            + "              ) AS subquery\n"
-            + "LIMIT 1;", nativeQuery = true)
+    @Query(value = """
+            SELECT * FROM ticket_stock ts  WHERE ts.ticket_id = :#{#ticketId} AND ts.ticket_stock_member_id IS NULL
+             LIMIT 1 FOR UPDATE SKIP LOCKED;
+            """, nativeQuery = true)
     Optional<TicketStock> findByTicketForUpdate(@Param("ticketId") Long ticketId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketService.java
@@ -8,8 +8,9 @@ import com.wootecam.festivals.domain.ticket.dto.TicketIdResponse;
 import com.wootecam.festivals.domain.ticket.dto.TicketListResponse;
 import com.wootecam.festivals.domain.ticket.dto.TicketResponse;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
-import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
+import com.wootecam.festivals.domain.ticket.repository.TicketStockJdbcRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TicketService {
 
     private final TicketRepository ticketRepository;
-    private final TicketStockRepository ticketStockRepository;
+    private final TicketStockJdbcRepository ticketStockJdbcRepository;
     private final FestivalRepository festivalRepository;
 
     /**
@@ -49,7 +50,8 @@ public class TicketService {
         Ticket newTicket = ticketRepository.save(request.toEntity(festival));
         log.debug("티켓 엔티티 생성 - 티켓 ID: {}", newTicket.getId());
 
-        ticketStockRepository.save(newTicket.createTicketStock());
+        List<TicketStock> ticketStock = newTicket.createTicketStock();
+        ticketStockJdbcRepository.saveTicketStocks(ticketStock);
         log.debug("티켓 재고 생성 완료 - 티켓 ID: {}", newTicket.getId());
 
         TicketIdResponse response = new TicketIdResponse(newTicket.getId());

--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -74,23 +74,33 @@ spring:
     username: ${secret-datasource.username}
     password: ${secret-datasource.password}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20 # 최대 커넥션 수 커스텀하게 사용
+      minimum-idle: 20 # 최소 idle 커넥션 수 커스텀하게 사용
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
+#    show-sql: true
     properties:
       hibernate:
-        format_sql: true
+#        format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
         generate_statistics: true
   data:
     redis:
       host: redis
       port: 6379
+    task:
+      execution:
+        pool:
+          core-size: 15   # 기본 스프링 비동기 스레드 풀 크기 커스텀하게 사용 (CPU 점유율 확인)
+          max-size: 50   # 최대 스프링 비동기 스레드 풀 크기 커스텀하게 사용 (CPU 점유율 확인)
+          queue-capacity: 2000 # 큐의 최대 용량
 logging:
   level:
-    org.hibernate.SQL: debug
-    com.wootecam.festivals: debug
+    org.hibernate.SQL: off
+    com.wootecam.festivals: error
+    org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: off
 ---
 spring:
   config:

--- a/backend/api-server/src/main/resources/data/ddl.sql
+++ b/backend/api-server/src/main/resources/data/ddl.sql
@@ -9,7 +9,7 @@ create table if not exists twodari.checkin
     member_id    bigint      not null,
     ticket_id    bigint      not null,
     updated_at   datetime(6) not null
-) engine=InnoDB;
+);
 
 create index checkin_festival_id_index
     on twodari.checkin (festival_id);
@@ -35,7 +35,7 @@ create table if not exists twodari.festival
     festival_img                varchar(255)                              null,
     festival_progress_status    enum ('COMPLETED', 'ONGOING', 'UPCOMING') not null,
     festival_publication_status enum ('DRAFT', 'PUBLISHED')               not null
-) engine=InnoDB;
+);
 
 create index FKdyfiny3xeeh1t7n7w3v30gyf7
     on twodari.festival (admin_id);
@@ -55,7 +55,7 @@ create table if not exists twodari.member
     profile_img varchar(255) null,
     constraint UKmbmcqelty0fbrvxp1q58dn57t
         unique (email)
-) engine=InnoDB;
+);
 
 create table if not exists twodari.purchase
 (
@@ -67,7 +67,7 @@ create table if not exists twodari.purchase
     ticket_id       bigint                         not null,
     updated_at      datetime(6)                    not null,
     purchase_status enum ('PURCHASED', 'REFUNDED') not null
-) engine=InnoDB;
+);
 
 create index purchase_member_id_index
     on twodari.purchase (member_id);
@@ -93,21 +93,21 @@ create table if not exists twodari.ticket
     updated_at      datetime(6)  null,
     ticket_detail   varchar(255) not null,
     ticket_name     varchar(255) not null
-) engine=InnoDB;
+);
 
 create index ticket_festival_id_index
     on twodari.ticket (festival_id);
 
 create table if not exists twodari.ticket_stock
 (
-    ticket_purchase_id bigint auto_increment
+    ticket_stock_id        bigint auto_increment
         primary key,
-    ticket_stock       int         not null,
-    created_at         datetime(6) not null,
-    ticket_id          bigint      not null,
-    updated_at         datetime(6) not null
-) engine=InnoDB;
+    ticket_id              bigint      not null,
+    ticket_stock_member_id bigint      null,
+    created_at             datetime(6) not null,
+    updated_at             datetime(6) not null
+);
 
-create index ticket_stock_ticket_id_index
-    on twodari.ticket_stock (ticket_id);
+create index ticket_stock_ticket_id_ticket_stock_member_id_index
+    on twodari.ticket_stock (ticket_id, ticket_stock_member_id);
 

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/PurchaseSyncTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/PurchaseSyncTest.java
@@ -16,6 +16,7 @@ import com.wootecam.festivals.domain.purchase.service.PurchaseService;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
+import com.wootecam.festivals.domain.ticket.repository.TicketStockJdbcRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
@@ -49,13 +50,9 @@ class PurchaseSyncTest extends SpringBootTestConfig {
     private TicketRepository ticketRepository;
 
     @Autowired
-    private CheckinRepository checkinRepository;
-
-    @Autowired
     private TicketStockRepository ticketStockRepository;
-
     @Autowired
-    private PurchaseRepository purchaseRepository;
+    private TicketStockJdbcRepository ticketStockJdbcRepository;
 
     @BeforeEach
     void setup() {
@@ -133,10 +130,8 @@ class PurchaseSyncTest extends SpringBootTestConfig {
                 .quantity(quantity)
                 .price(10000L)
                 .build());
-        ticketStockRepository.save(TicketStock.builder()
-                .ticket(saved)
-                .remainStock(saved.getQuantity())
-                .build());
+        List<TicketStock> ticketStocks = saved.createTicketStock();
+        ticketStockJdbcRepository.saveTicketStocks(ticketStocks);
 
         return saved;
     }

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchasableAuthorityCleanupScheduleServiceTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchasableAuthorityCleanupScheduleServiceTest.java
@@ -1,6 +1,6 @@
 package com.wootecam.festivals.domain.purchase.service;
 
-import static com.wootecam.festivals.domain.purchase.controller.PurchaseController.PURCHASABLE_TICKET_KEY;
+import static com.wootecam.festivals.domain.purchase.controller.PurchaseController.PURCHASABLE_TICKET_STOCK_KEY;
 import static com.wootecam.festivals.domain.purchase.controller.PurchaseController.PURCHASABLE_TICKET_TIMESTAMP_KEY;
 import static com.wootecam.festivals.utils.Fixture.createFestival;
 import static com.wootecam.festivals.utils.Fixture.createMember;
@@ -9,11 +9,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
-import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.ticket.repository.TicketStockJdbcRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.config.CustomMapSessionRepository;
 import com.wootecam.festivals.global.utils.TimeProvider;
@@ -50,6 +51,9 @@ class PurchasableAuthorityCleanupScheduleServiceTest extends SpringBootTestConfi
     @Autowired
     private TicketStockRepository ticketStockRepository;
 
+    @Autowired
+    private TicketStockJdbcRepository ticketStockJdbcRepository;
+
     @Nested
     @DisplayName("cleanUpSessions 메소드는")
     class Describe_cleanUpSessions {
@@ -65,8 +69,9 @@ class PurchasableAuthorityCleanupScheduleServiceTest extends SpringBootTestConfi
             Member admin = memberRepository.save(createMember("admin", "admin@test.com"));
             festival = festivalRepository.save(createFestival(admin, "Test Festival", "Test Festival Detail",
                     ticketSaleStartTime.plusDays(1), ticketSaleStartTime.plusDays(4)));
-            ticket = ticketRepository.save(createTicket(festival, 10000L, 100, ticketSaleStartTime, ticketSaleStartTime.plusDays(3)));
-            ticketStockRepository.save(ticket.createTicketStock());
+            ticket = ticketRepository.save(
+                    createTicket(festival, 10000L, 100, ticketSaleStartTime, ticketSaleStartTime.plusDays(3)));
+            ticketStockJdbcRepository.saveTicketStocks(ticket.createTicketStock());
         }
 
         @Nested
@@ -78,8 +83,9 @@ class PurchasableAuthorityCleanupScheduleServiceTest extends SpringBootTestConfi
             @BeforeEach
             void setUp() {
                 session1 = sessionRepository.createSession();
-                session1.setAttribute(PURCHASABLE_TICKET_TIMESTAMP_KEY, LocalDateTime.parse("2021-08-01T00:00:00").toString());
-                session1.setAttribute(PURCHASABLE_TICKET_KEY, ticket.getId());
+                session1.setAttribute(PURCHASABLE_TICKET_TIMESTAMP_KEY,
+                        LocalDateTime.parse("2021-08-01T00:00:00").toString());
+                session1.setAttribute(PURCHASABLE_TICKET_STOCK_KEY, ticket.getId());
                 sessionRepository.save(session1);
 
                 given(timeProvider.getCurrentTime()).willReturn(LocalDateTime.parse("2021-08-04T00:00:01"));
@@ -94,7 +100,7 @@ class PurchasableAuthorityCleanupScheduleServiceTest extends SpringBootTestConfi
                 // Then
                 MapSession savedSession1 = sessionRepository.findById(session1.getId());
                 assertThat((String) savedSession1.getAttribute(PURCHASABLE_TICKET_TIMESTAMP_KEY)).isNull();
-                assertThat((Long) savedSession1.getAttribute(PURCHASABLE_TICKET_KEY)).isNull();
+                assertThat((Long) savedSession1.getAttribute(PURCHASABLE_TICKET_STOCK_KEY)).isNull();
             }
         }
 
@@ -107,8 +113,9 @@ class PurchasableAuthorityCleanupScheduleServiceTest extends SpringBootTestConfi
             @BeforeEach
             void setUp() {
                 session1 = sessionRepository.createSession();
-                session1.setAttribute(PURCHASABLE_TICKET_TIMESTAMP_KEY, LocalDateTime.parse("2021-08-04T00:00:00").toString());
-                session1.setAttribute(PURCHASABLE_TICKET_KEY, ticket.getId());
+                session1.setAttribute(PURCHASABLE_TICKET_TIMESTAMP_KEY,
+                        LocalDateTime.parse("2021-08-04T00:00:00").toString());
+                session1.setAttribute(PURCHASABLE_TICKET_STOCK_KEY, ticket.getId());
                 sessionRepository.save(session1);
 
                 given(timeProvider.getCurrentTime()).willReturn(LocalDateTime.parse("2021-08-01T00:00:00"));
@@ -123,7 +130,7 @@ class PurchasableAuthorityCleanupScheduleServiceTest extends SpringBootTestConfi
                 // Then
                 MapSession savedSession1 = sessionRepository.findById(session1.getId());
                 assertThat((String) savedSession1.getAttribute(PURCHASABLE_TICKET_TIMESTAMP_KEY)).isNotNull();
-                assertThat((Long) savedSession1.getAttribute(PURCHASABLE_TICKET_KEY)).isNotNull();
+                assertThat((Long) savedSession1.getAttribute(PURCHASABLE_TICKET_STOCK_KEY)).isNotNull();
             }
         }
     }

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeServiceTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseFacadeServiceTest.java
@@ -16,9 +16,11 @@ import com.wootecam.festivals.domain.purchase.repository.PurchaseRepository;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
+import com.wootecam.festivals.domain.ticket.repository.TicketStockJdbcRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -70,6 +72,7 @@ class PurchaseFacadeServiceTest extends SpringBootTestConfig {
     class Describe_createPurchase {
 
         Ticket ticket;
+        TicketStock ticketStock;
 
         @BeforeEach
         void setUp() {
@@ -84,14 +87,18 @@ class PurchaseFacadeServiceTest extends SpringBootTestConfig {
                     .refundEndTime(ticketSaleStartTime.plusDays(2))
                     .festival(festival)
                     .build());
-            ticketStockRepository.save(ticket.createTicketStock());
+            ticketStock = TicketStock.builder()
+                    .ticket(ticket)
+                    .build();
+            ticketStock.reserveTicket(member.getId());
+            ticketStock = ticketStockRepository.save(ticketStock);
         }
 
         @Test
         @DisplayName("티켓을 구매할 수 있다.")
         void It_return_new_purchase() {
             PurchaseTicketResponse response = purchaseFacadeService.purchaseTicket(member.getId(),
-                    festival.getId(), ticket.getId());
+                    festival.getId(), ticket.getId(), ticketStock.getId());
 
             assertAll(
                     () -> assertNotNull(response),

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/TicketStockRollbackerTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/TicketStockRollbackerTest.java
@@ -3,14 +3,15 @@ package com.wootecam.festivals.domain.purchase.service;
 import static com.wootecam.festivals.utils.Fixture.createFestival;
 import static com.wootecam.festivals.utils.Fixture.createMember;
 import static com.wootecam.festivals.utils.Fixture.createTicket;
-import static com.wootecam.festivals.utils.Fixture.createTicketStock;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.entity.TicketStock;
 import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
@@ -49,6 +50,7 @@ class TicketStockRollbackerTest extends SpringBootTestConfig {
         private Member member;
         private Festival festival;
         private Ticket ticket;
+        private TicketStock ticketStock;
         private LocalDateTime ticketSaleStartTime = LocalDateTime.now();
 
         @BeforeEach
@@ -58,33 +60,28 @@ class TicketStockRollbackerTest extends SpringBootTestConfig {
             Member admin = memberRepository.save(createMember("admin", "admin@test.com"));
             festival = festivalRepository.save(createFestival(admin, "Test Festival", "Test Festival Detail",
                     ticketSaleStartTime.plusDays(1), ticketSaleStartTime.plusDays(4)));
-            ticket = ticketRepository.save(createTicket(festival, 10000L, 100, ticketSaleStartTime, ticketSaleStartTime.plusDays(3)));
+            ticket = ticketRepository.save(
+                    createTicket(festival, 10000L, 100, ticketSaleStartTime, ticketSaleStartTime.plusDays(3)));
+            ticketStock = TicketStock.builder().ticket(ticket).build();
+            ticketStockRepository.save(ticketStock);
         }
 
         @Test
         @DisplayName("해당 티켓의 재고 정보를 복구한다")
         void rollbackTicketStock() {
-            // Given
-            Long ticketId = ticket.getId();
-            int quantity = 1;
-            ticketStockRepository.save(createTicketStock(ticket, 99));
+            ticketStockRollbacker.rollbackTicketStock(ticketStock.getId());
 
-            // When
-            ticketStockRollbacker.rollbackTicketStock(ticketId, quantity);
-
-            // Then
-            assertEquals(100, ticketStockRepository.findByTicket(ticket).get().getRemainStock());
+            assertFalse(ticketStockRepository.findById(ticketStock.getId()).get().isReservation());
         }
 
         @Test
         @DisplayName("해당 티켓의 재고 정보가 존재하지 않을 때 IllegalArgumentException을 던진다")
         void throwsIllegalArgumentExceptionWhenTicketStockNotFound() {
             // Given
-            Long ticketId = ticket.getId();
-            int quantity = 1;
-
+            Long ticketStockId = -1L;
             // When, Then
-            assertThrows(IllegalArgumentException.class, () -> ticketStockRollbacker.rollbackTicketStock(ticketId, quantity));
+            assertThrows(IllegalArgumentException.class,
+                    () -> ticketStockRollbacker.rollbackTicketStock(ticketStockId));
         }
     }
 }

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/TicketStockRollbackerTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/TicketStockRollbackerTest.java
@@ -71,7 +71,7 @@ class TicketStockRollbackerTest extends SpringBootTestConfig {
         void rollbackTicketStock() {
             ticketStockRollbacker.rollbackTicketStock(ticketStock.getId());
 
-            assertFalse(ticketStockRepository.findById(ticketStock.getId()).get().isReservation());
+            assertFalse(ticketStockRepository.findById(ticketStock.getId()).get().isReserved());
         }
 
         @Test

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/controller/TicketControllerTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/controller/TicketControllerTest.java
@@ -166,7 +166,7 @@ class TicketControllerTest extends RestDocsSupport {
         List<TicketResponse> tickets = new ArrayList<>();
         for (int i = 1; i <= 5; i++) {
             tickets.add(new TicketResponse((long) i, "티켓 이름" + i, "티켓 설명" + i,
-                    1000L, 100, 100,
+                    1000L, 100, 100L,
                     LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(2), LocalDateTime.now().plusDays(3),
                     LocalDateTime.now(), LocalDateTime.now()));
         }
@@ -182,6 +182,7 @@ class TicketControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.tickets[0].detail").value("티켓 설명1"))
                 .andExpect(jsonPath("$.data.tickets[0].price").value(1000L))
                 .andExpect(jsonPath("$.data.tickets[0].quantity").value(100))
+                .andExpect(jsonPath("$.data.tickets[0].remainStock").value(100))
                 .andDo(restDocs.document(
                         pathParameters(
                                 parameterWithName("festivalId").description("축제 ID")
@@ -196,7 +197,7 @@ class TicketControllerTest extends RestDocsSupport {
                                 fieldWithPath("detail").type(JsonFieldType.STRING).description("티켓 설명"),
                                 fieldWithPath("price").type(JsonFieldType.NUMBER).description("티켓 가격"),
                                 fieldWithPath("quantity").type(JsonFieldType.NUMBER).description("티켓 수량"),
-                                fieldWithPath("remainStock").type(JsonFieldType.NUMBER).description("남은 티켓 수량"),
+                                fieldWithPath("remainStock").type(JsonFieldType.NUMBER).description("티켓 재고 ID"),
                                 fieldWithPath("startSaleTime").type(JsonFieldType.STRING).description("티켓 판매 시작 시간"),
                                 fieldWithPath("endSaleTime").type(JsonFieldType.STRING).description("티켓 판매 종료 시간"),
                                 fieldWithPath("refundEndTime").type(JsonFieldType.STRING).description("티켓 환불 종료 시간"),

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketStockTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketStockTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import com.wootecam.festivals.domain.festival.stub.FestivalStub;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,8 +14,8 @@ import org.junit.jupiter.api.Test;
 public class TicketStockTest {
 
     @Nested
-    @DisplayName("decreaseStock는")
-    class Describe_decreaseStock {
+    @DisplayName("sellTicketStock은")
+    class Describe_sellTicketStock {
 
         LocalDateTime now = LocalDateTime.now();
         Festival festival = FestivalStub.createFestivalWithTime(now, LocalDateTime.now().plusDays(7));
@@ -30,55 +31,47 @@ public class TicketStockTest {
                 .build();
 
         @Nested
-        @DisplayName("남은 재고가 1 이상일 때")
+        @DisplayName("남은 재고가 있을 때")
         class Context_with_remain_stock_more_than_one {
 
             TicketStock ticketStock = TicketStock.builder()
-                    .remainStock(2)
                     .ticket(ticket)
                     .build();
 
-            @DisplayName("재고를 차감하면 남은 재고가 1 감소한다")
+            @DisplayName("재고를 차감하면 티켓 재고는 예약(점유) 상태가 된다.")
             @Test
             void It_decreases_remain_stock_by_one() {
-                ticketStock.decreaseStock();
+                ticketStock.reserveTicket(1L);
 
-                assertThat(ticketStock.getRemainStock()).isEqualTo(1);
+                assertThat(ticketStock.isReservation()).isEqualTo(true);
             }
         }
 
         @Nested
-        @DisplayName("남은 재고가 1일 때")
-        class Context_with_remain_stock_is_one {
+        @DisplayName("티켓 재고가 팔리면")
+        class Context_with_no_remain_stock {
 
-            TicketStock ticketStock = TicketStock.builder()
-                    .remainStock(1)
-                    .ticket(ticket)
-                    .build();
+            TicketStock ticketStock;
 
-            @DisplayName("재고를 차감하면 남은 재고가 0이 된다")
-            @Test
-            void It_decreases_remain_stock_to_zero() {
-                ticketStock.decreaseStock();
-
-                assertThat(ticketStock.getRemainStock()).isEqualTo(0);
+            @BeforeEach
+            void setUp() {
+                ticketStock = TicketStock.builder()
+                        .ticket(ticket)
+                        .build();
             }
-        }
 
-        @Nested
-        @DisplayName("남은 재고가 0일 때")
-        class Context_with_remain_stock_is_zero {
-
-            TicketStock ticketStock = TicketStock.builder()
-                    .remainStock(0)
-                    .ticket(ticket)
-                    .build();
-
-            @DisplayName("재고를 차감하면 예외가 발생한다")
+            @DisplayName("이미 점유된 재고를 사려고 하면 예외를 던진다.")
             @Test
-            void It_throws_exception() {
-                assertThatThrownBy(ticketStock::decreaseStock)
+            void It_throws_exception_when_sell_stock() {
+                ticketStock.reserveTicket(100L);
+                assertThatThrownBy(() -> ticketStock.reserveTicket(101L))
                         .isInstanceOf(IllegalStateException.class);
+            }
+
+            @DisplayName("해당 티켓 재고가 예약(점유)되지 않았다면 은 false가 된다.")
+            @Test
+            void It_not_sell_stock_is_reservation() {
+                assertThat(ticketStock.isReservation()).isFalse();
             }
         }
     }

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketStockTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketStockTest.java
@@ -43,7 +43,7 @@ public class TicketStockTest {
             void It_decreases_remain_stock_by_one() {
                 ticketStock.reserveTicket(1L);
 
-                assertThat(ticketStock.isReservation()).isEqualTo(true);
+                assertThat(ticketStock.isReserved()).isEqualTo(true);
             }
         }
 
@@ -71,7 +71,7 @@ public class TicketStockTest {
             @DisplayName("해당 티켓 재고가 예약(점유)되지 않았다면 은 false가 된다.")
             @Test
             void It_not_sell_stock_is_reservation() {
-                assertThat(ticketStock.isReservation()).isFalse();
+                assertThat(ticketStock.isReserved()).isFalse();
             }
         }
     }

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/entity/TicketTest.java
@@ -11,6 +11,7 @@ import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.purchase.entity.Purchase;
 import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -65,12 +66,11 @@ class TicketTest {
         @Test
         @DisplayName("티켓 재고 생성에 성공한다.")
         void it_returns_ticketStock() {
-            TicketStock ticketStock = ticket.createTicketStock();
+            List<TicketStock> ticketStocks = ticket.createTicketStock();
 
             assertAll(
-                    () -> assertThat(ticketStock).isNotNull(),
-                    () -> assertThat(ticketStock.getTicket()).isEqualTo(ticket),
-                    () -> assertThat(ticketStock.getRemainStock()).isEqualTo(ticket.getQuantity())
+                    () -> assertThat(ticketStocks.size()).isEqualTo(ticket.getQuantity()),
+                    () -> assertThat(ticketStocks.get(0).getTicket()).isEqualTo(ticket)
             );
         }
 

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/repository/TicketStockJdbcRepositoryTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/repository/TicketStockJdbcRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.wootecam.festivals.domain.ticket.repository;
+
+import static com.wootecam.festivals.utils.Fixture.createFestival;
+import static com.wootecam.festivals.utils.Fixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wootecam.festivals.domain.festival.entity.Festival;
+import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
+import com.wootecam.festivals.domain.member.entity.Member;
+import com.wootecam.festivals.domain.member.repository.MemberRepository;
+import com.wootecam.festivals.domain.ticket.entity.Ticket;
+import com.wootecam.festivals.domain.ticket.entity.TicketStock;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TicketStockJdbcRepositoryTest extends SpringBootTestConfig {
+
+    private final TicketStockJdbcRepository ticketStockJdbcRepository;
+    private final MemberRepository memberRepository;
+    private final FestivalRepository festivalRepository;
+    private final TicketRepository ticketRepository;
+    private final TicketStockRepository ticketStockRepository;
+
+    private Festival festival;
+    private Member admin;
+    private LocalDateTime ticketSaleStartTime = LocalDateTime.now();
+    @Autowired
+    TicketStockJdbcRepositoryTest(TicketStockJdbcRepository ticketStockJdbcRepository,
+                                  MemberRepository memberRepository, FestivalRepository festivalRepository,
+                                  TicketRepository ticketRepository, TicketStockRepository ticketStockRepository) {
+        this.ticketStockJdbcRepository = ticketStockJdbcRepository;
+        this.memberRepository = memberRepository;
+        this.festivalRepository = festivalRepository;
+        this.ticketRepository = ticketRepository;
+        this.ticketStockRepository = ticketStockRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        clear();
+
+        admin = memberRepository.save(createMember("admin", "admin@test.com"));
+        festival = festivalRepository.save(createFestival(admin, "Test Festival", "Test Festival Detail",
+                ticketSaleStartTime.plusDays(1), ticketSaleStartTime.plusDays(4)));
+    }
+
+    @Test
+    @DisplayName("티켓 재고 배치 저장")
+    void saveTicketStocks() {
+        // given
+        Ticket ticket = ticketRepository.save(Ticket.builder()
+                .name("Test Ticket")
+                .detail("Test Ticket Detail")
+                .price(10000L)
+                .quantity(100)
+                .startSaleTime(ticketSaleStartTime)
+                .endSaleTime(ticketSaleStartTime.plusDays(2))
+                .refundEndTime(ticketSaleStartTime.plusDays(2))
+                .festival(festival)
+                .build());
+
+        Ticket save = ticketRepository.save(ticket);
+        // when
+        ticketStockJdbcRepository.saveTicketStocks(save.createTicketStock());
+
+        // then
+        List<TicketStock> ticketStocks = ticketStockRepository.findAll();
+
+        assertThat(ticketStocks).hasSize(100);
+    }
+
+}

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/ticket/service/TicketServiceTest.java
@@ -18,6 +18,7 @@ import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -79,14 +80,12 @@ class TicketServiceTest extends SpringBootTestConfig {
 
             // When
             TicketIdResponse ticketIdResponse = ticketService.createTicket(saveFestival.getId(), ticketCreateRequest);
-
+            Optional<Ticket> findTicket = ticketRepository.findById(ticketIdResponse.ticketId());
             // Then
             assertAll(
                     () -> assertThat(ticketIdResponse).isNotNull(),
-                    () -> assertThat(ticketRepository.findAll()).hasSize(1),
-                    () -> assertThat(ticketStockRepository.findAll()).hasSize(1)
-                            .extracting("remainStock")
-                            .containsExactly(ticketStockRepository.findAll().get(0).getRemainStock())
+                    () -> assertThat(findTicket.isPresent()).isTrue(),
+                    () -> assertThat(ticketStockRepository.findAll()).hasSize(findTicket.get().getQuantity())
             );
         }
 
@@ -145,7 +144,6 @@ class TicketServiceTest extends SpringBootTestConfig {
 
                 TicketStock ticketStock = TicketStock.builder()
                         .ticket(ticket)
-                        .remainStock(100)
                         .build();
 
                 ticketRepository.save(ticket);

--- a/backend/api-server/src/test/java/com/wootecam/festivals/utils/Fixture.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/utils/Fixture.java
@@ -47,7 +47,6 @@ public final class Fixture {
     public static TicketStock createTicketStock(Ticket ticket, int stock) {
         return TicketStock.builder()
                 .ticket(ticket)
-                .remainStock(stock)
                 .build();
     }
 }


### PR DESCRIPTION
## 📄 작업 설명
한 레코드로 관리할 경우 동시성 이슈로 하나의 데이터에 대해 lock이 동작을 하는데 티켓 수량만큼 레코드를 만든다면 여러 개의 트랜잭션이 각각의 레코드를 걸어 하나의 레코드에 대해 락을 기다리지 않고 여러개의 레코드로 접근하여 처리할 수 있도록 했어요 !

그래서 하나의 티켓의 재고 100개면 티켓 재고 엔티티가 100개 생긴다고 생각하시면 됩니다.
DDL 변경과 각 테스트 변경이 있으니 유심히 봐주세요 !

## 🚨 관련 이슈
closes #124 

## 🌈 작업 상황
- TicketStock 엔티티 변경
- 서비스 로직, Query 추가
- 테스트 변경
- DDL 변경
## 📌 기타
