### PR TITLE
hotfix#140 내가 참여한 페스티벌 목록 조회 ticketId 반환하도록 수정

### DIFF
--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedFestivalResponse.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/my/dto/MyPurchasedFestivalResponse.java
@@ -19,6 +19,7 @@ public record MyPurchasedFestivalResponse(
         FestivalAdminResponse admin,
         Long purchaseId,
         @JsonSerialize(using = CustomLocalDateTimeSerializer.class)
-        LocalDateTime purchaseTime
+        LocalDateTime purchaseTime,
+        Long ticketId
 ){
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/repository/PurchaseRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/repository/PurchaseRepository.java
@@ -40,7 +40,7 @@ public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
                     new com.wootecam.festivals.domain.festival.dto.FestivalAdminResponse(
                         a.id, a.name, a.email, a.profileImg
                     ),
-                    p.id, p.purchaseTime
+                    p.id, p.purchaseTime, t.id
                 )
                 FROM Purchase p
                 JOIN p.ticket t

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/my/controller/MyControllerTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/my/controller/MyControllerTest.java
@@ -179,6 +179,7 @@ class MyControllerTest extends RestDocsSupport {
                                 fieldWithPath("content[].admin.profileImg").type(JsonFieldType.STRING).description("관리자 프로필 이미지"),
                                 fieldWithPath("content[].purchaseId").type(JsonFieldType.NUMBER).description("구매 ID"),
                                 fieldWithPath("content[].purchaseTime").type(JsonFieldType.STRING).description("구매 시간"),
+                                fieldWithPath("content[].ticketId").type(JsonFieldType.NUMBER).description("티켓 ID"),
                                 fieldWithPath("cursor").type(JsonFieldType.OBJECT).description("다음 페이지 커서 정보"),
                                 fieldWithPath("cursor.startTime").type(JsonFieldType.STRING).description("다음 페이지의 시작 시각 커서"),
                                 fieldWithPath("cursor.id").type(JsonFieldType.NUMBER).description("다음 페이지의 ID 커서"),
@@ -228,7 +229,8 @@ class MyControllerTest extends RestDocsSupport {
                         FestivalProgressStatus.UPCOMING,
                         new FestivalAdminResponse(1L, "관리자" + i, "admin" + i + "@example.com", "profile" + i + ".jpg"),
                         (long) (count + 1 - i),
-                        now.minusDays(i)
+                        now.minusDays(i),
+                        100L
                 ))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 📄 작업 설명
내가 참여한 페스티벌 목록 조회 ticketId 반환하도록 수정하여 구매한 티켓 조회할때 사용할 수 있도록 함

## 🚨 관련 이슈
closes #140 

## 🌈 작업 상황
- 응답값에 ticketId 추가 완료

## 📌 기타
