### PR TITLE
hotfix#162/front festival List 페이지 버그 수정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.4",
         "jsqr": "^1.4.0",
+        "lodash": "^4.17.21",
         "lucide-react": "^0.428.0",
         "qrcode.react": "^4.0.0",
         "react": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.4",
     "jsqr": "^1.4.0",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.428.0",
     "qrcode.react": "^4.0.0",
     "react": "^18.3.1",

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-    baseURL: '/api/v1', // 배포
+    // baseURL: '/api/v1', // 배포
     // baseURL: 'http://twodari.shop/api/v1',
-    // baseURL: 'http://localhost:8080/api/v1',
+    baseURL: 'http://localhost:8080/api/v1',
     withCredentials: true,
 });
 

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-    // baseURL: '/api/v1', // 배포
+    baseURL: '/api/v1', // 배포
     // baseURL: 'http://twodari.shop/api/v1',
-    baseURL: 'http://localhost:8080/api/v1',
+    // baseURL: 'http://localhost:8080/api/v1',
     withCredentials: true,
 });
 


### PR DESCRIPTION
## 📄 작업 설명
- 축제 목록 화면에서 무한스크롤이 중복돼서 나오는 문제를 수정하였습니다.
- 축제 목록 화면에서 서버에 요청이 정상적으로 처리되지 않을 경우 반복적으로 요청을 보내고 있었습니다. 이는 서버가 언제 복구될지 모르는데 네트워크 요청을 계속 하게됩니다. 따라서 3회 재시도 제한을 걸고 그 후에는 오류 메시지를 보여주도록 변경하였습니다.
## 🚨 관련 이슈
closes #162 

## 🌈 작업 상황

## 📌 기타
